### PR TITLE
Refactor home directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.pyc
+.vscode/

--- a/fabfile/__init__.py
+++ b/fabfile/__init__.py
@@ -1,5 +1,7 @@
 from fabric.api import env, task, execute, runs_once, abort
 
+import config
+
 def mess_with_roledefs(environment):
     '''
     For some reason -R and -H and, by default, lowest in the order of precedence.
@@ -21,7 +23,7 @@ def mess_with_roledefs(environment):
 
     environment.roledefs = {
         'master': ['localhost'],
-        'workers': [ip.strip() for ip in open('/home/ec2-user/test-automation/worker-instances')],
+        'workers': [ip.strip() for ip in open(config.HOME_DIR + '/test-automation/worker-instances')],
     }
 
     if environment.hosts or environment.roles:

--- a/fabfile/config.py
+++ b/fabfile/config.py
@@ -1,12 +1,16 @@
+from os.path import expanduser
+
+HOME_DIR = expanduser("~")
+
 paths = {
-    'code-directory': '/home/ec2-user/code',
-    'tests-repo': '/home/ec2-user/test-automation',
-    'citus-repo': '/home/ec2-user/citus',
-    'enterprise-repo': '/home/ec2-user/citus-enterprise',
-    'pg-latest': '/home/ec2-user/pg-latest',
-    'pg-source-balls': '/home/ec2-user/postgres-source',
-    'home-directory': '/home/ec2-user/',
-    'citus-installation': '/home/ec2-user/citus-installation'
+    'code-directory': HOME_DIR + '/code',
+    'tests-repo': HOME_DIR + '/test-automation',
+    'citus-repo': HOME_DIR + '/citus',
+    'enterprise-repo': HOME_DIR + '/citus-enterprise',
+    'pg-latest': HOME_DIR + '/pg-latest',
+    'pg-source-balls': HOME_DIR + '/postgres-source',
+    'home-directory': HOME_DIR, 
+    'citus-installation': HOME_DIR + '/citus-installation'
 }
 
 settings = {

--- a/fabfile/prefix.py
+++ b/fabfile/prefix.py
@@ -1,5 +1,5 @@
 '''
-/home/ec2-user/pg-latest (config.paths['pg-latest']) should always point to the
+$HOME/pg-latest (config.paths['pg-latest']) should always point to the
 installation of citus we're currently working with. This way tasks which interact with an
 installation can just use pg-latest and not care where it points to. (We use this instead
 of something like a "use" task because this is long-term state which should be kept
@@ -18,7 +18,7 @@ def set_prefix(prefix):
 
     if not os.path.isabs(prefix):
         abort('{} is not an absolute path'.format(prefix))
-
+        
     latest = config.paths['pg-latest']
 
     # -f to overwrite any existing links

--- a/fabfile/run.py
+++ b/fabfile/run.py
@@ -19,7 +19,7 @@ __all__ = ['jdbc', 'regression', 'pgbench_tests', 'tpch_automate']
 @roles('master')
 def jdbc():
     'Assumes add.jdbc and add.tpch have been run'
-    with cd('/home/ec2-user/test-automation/jdbc'):
+    with cd(config.HOME_DIR + '/test-automation/jdbc'):
         run('javac JDBCReleaseTest.java')
         run('java -classpath postgresql-9.4.1212.jre6.jar:. JDBCReleaseTest')
 
@@ -38,7 +38,7 @@ def regression():
 def pgbench_tests(config_file='pgbench_default.ini', connectionURI=''):
     config_parser = ConfigParser.ConfigParser()
 
-    config_folder_path = "/home/ec2-user/test-automation/fabfile/pgbench_confs/"
+    config_folder_path = config.HOME_DIR + "/test-automation/fabfile/pgbench_confs/"
     config_parser.read(config_folder_path + config_file)
 
     current_time_mark = time.strftime('%Y-%m-%d-%H-%M')
@@ -159,7 +159,7 @@ def pgbench_tests(config_file='pgbench_default.ini', connectionURI=''):
 def tpch_automate(config_file='tpch_default.ini', connectionURI=''):
     config_parser = ConfigParser.ConfigParser()
 
-    config_folder_path = "/home/ec2-user/test-automation/fabfile/tpch_confs/"
+    config_folder_path = config.HOME_DIR + "/test-automation/fabfile/tpch_confs/"
     config_parser.read(config_folder_path + config_file)
 
     for section in config_parser.sections():

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -24,7 +24,7 @@ def psql(command, connectionURI=''):
 def add_github_to_known_hosts():
     'Removes prompts from github checkouts asking whether you want to trust the remote'
     key = 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
-    append('/home/ec2-user/.ssh/known_hosts', key)
+    append(config.HOME_DIR + '/.ssh/known_hosts', key)
 
 def download_pg():
     "Idempotent, does not download if file already exists. Returns the file's location"


### PR DESCRIPTION
This PR:

- Uses home directory from config instead of hard coded `/home/ec2-user`
- Adds `pyc` and `vscode` to `.gitignore` 

All of the paths in https://github.com/citusdata/test-automation/blob/master/cloudformation/citus.json are also hard coded, this should also be refactored. If we move to azure cloudformation will not be used so we can do this refactor later.
