### PR TITLE
Update test configs with recent PG and Citus versions and use enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ ssh -A ec2-user@ec2-35-153-66-69.compute-1.amazonaws.com
 ```
 
 On the coordinator node:
+
 ```bash
-# This will run default pgBench tests with PG=10.1 and Citus Enterprise 7.1 and 7.2 release branches
+# This will run default pgBench tests with PG=11.5 and Citus Enterprise 9.0 and 8.3 release branches
 # and it will log results to pgbench_results_{timemark}.csv file
 # Yes, that's all :) You can change settings in fabfile/pgbench_confs/pgbench_default.ini
 fab run.pgbench_tests

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ ssh -A ec2-user@ec2-35-153-66-69.compute-1.amazonaws.com
 
 On the coordinator node:
 ```bash
-# This will run scale tests with PG=10.1 and Citus Enterprise 7.1 and 7.2 release branches
+# This will run scale tests with PG=11.5 and Citus Enterprise 9.0 and 8.3 release branches
 # and it will log results to pgbench_results_{timemark}.csv file
 # You can change settings in files under the fabfile/pgbench_confs/ directory
 fab run.pgbench_tests:scale_test.ini
@@ -192,7 +192,7 @@ ssh -A ec2-user@ec2-35-153-66-69.compute-1.amazonaws.com
 
 On the coordinator node:
 ```bash
-# This will run TPC-H tests with PG=10.1 and Citus Enterprise 7.1 and 7.2 release branches
+# This will run TPC-H tests with PG=11.5 and Citus Enterprise 9.0 and 8.3 release branches
 # and it will log results to their own files on the home directory. You can use diff to 
 # compare results.
 # You can change settings in files under the fabfile/tpch_confs/ directory

--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -8,7 +8,7 @@ postgresql_conf: [
                  "max_prepared_transactions = 1000",
                  "citus.multi_shard_commit_protocol = '2pc'"
                  ]
-use_enterprise: off
+use_enterprise: on
 
 [citus1]
 sql_command: CREATE TABLE test_table(a int, b int, c int, d int);

--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.1', 'master'), ('10.1', 'v7.1.0')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_issue_1799.ini
+++ b/fabfile/pgbench_confs/pgbench_issue_1799.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.1', 'master')]
+postgres_citus_versions: [('11.5', 'release-9.0')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",
@@ -7,7 +7,7 @@ postgresql_conf: [
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000"
                  ]
-use_enterprise: off
+use_enterprise: on
 
 [create_type]
 sql_command: CREATE TYPE complex AS (r double precision, i double precision);

--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_100_columns.ini
+++ b/fabfile/pgbench_confs/scale_test_100_columns.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_foreign.ini
+++ b/fabfile/pgbench_confs/scale_test_foreign.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_no_index.ini
+++ b/fabfile/pgbench_confs/scale_test_no_index.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_prepared.ini
+++ b/fabfile/pgbench_confs/scale_test_prepared.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_reference.ini
+++ b/fabfile/pgbench_confs/scale_test_reference.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/tpch_confs/tpch_default.ini
+++ b/fabfile/tpch_confs/tpch_default.ini
@@ -1,6 +1,6 @@
 [test]
 use_enterprise: on
-postgres_citus_versions: [('10.3', 'release-7.3'), ('10.3', 'release-7.2')]
+postgres_citus_versions: [('11.5', 'release-9.0'), ('11.5', 'release-8.3')]
 tpch_tasks_executor_types: [('1.sql', 'real-time'), ('3.sql', 'task-tracker'), ('5.sql', 'task-tracker'), ('6.sql', 'real-time')
                             ,('7.sql', 'task-tracker'), ('8.sql', 'task-tracker'), ('9.sql', 'task-tracker'), ('10.sql', 'task-tracker')
                             , ('12.sql', 'real-time'), ('14.sql', 'task-tracker'), ('19.sql', 'task-tracker')]

--- a/fabfile/tpch_confs/tpch_q1.ini
+++ b/fabfile/tpch_confs/tpch_q1.ini
@@ -1,5 +1,5 @@
 [test]
-use_enterprise: off
-postgres_citus_versions: [('10.1', 'master')]
+use_enterprise: on
+postgres_citus_versions: [('11.5', 'release-9.0')]
 tpch_tasks_executor_types: [('1.sql', 'real-time')]
 scale_factor: 1


### PR DESCRIPTION
This PR updates all test configs to use pg11.5 and citus release-9.0.
It also changes all tests to use citus enterprise repository.

We can possibly change the `postgres-citus-versions` from a single variable instead of having them in each file. 