### PR TITLE
refactor hard coded config variables and create results folder

### DIFF
--- a/fabfile/add.py
+++ b/fabfile/add.py
@@ -41,7 +41,7 @@ class InstallExtensionTask(Task):
     def repo_path_for_url(repo_url):
         repo_name = run('basename {}'.format(repo_url))
         repo_name = repo_name.split('.')[0] # chop off the '.git' at the end
-        return os.path.join(config.paths['code-directory'], repo_name)
+        return os.path.join(config.paths[config.CODE_DIRECTORY], repo_name)
 
     def run(self, *args):
         if self.before_run_hook:
@@ -60,7 +60,7 @@ class InstallExtensionTask(Task):
         utils.rmdir(repo, force=True) # force because git write-protects files
         run('git clone -q {} {}'.format(self.repo_url, repo))
 
-        with cd(repo), path('{}/bin'.format(config.paths['pg-latest'])):
+        with cd(repo), path('{}/bin'.format(config.paths[config.PG_LATEST])):
             run('git checkout {}'.format(git_ref))
             run('make install')
 
@@ -83,7 +83,7 @@ hll = InstallExtensionTask(
 )
 
 def add_cstore_to_shared_preload_libraries():
-    conf = '{}/data/postgresql.conf'.format(config.paths['pg-latest'])
+    conf = '{}/data/postgresql.conf'.format(config.paths[config.PG_LATEST])
 
     existing_line = run('grep "^shared_preload_libraries" {}'.format(conf))
 
@@ -121,14 +121,14 @@ def tpch(**kwargs):
     'Generates and loads tpc-h data into the instance at pg-latest'
     prefix.check_for_pg_latest()
 
-    psql = '{}/bin/psql'.format(config.paths['pg-latest'])
+    psql = '{}/bin/psql'.format(config.paths[config.PG_LATEST])
 
     connectionURI = kwargs.get('connectionURI', kwargs.get('connectionURI', ''))
     scale = kwargs.get('scale-factor', kwargs.get('scale_factor', 10))
     partition_type = kwargs.get('partition-type', kwargs.get('partition_type', 'default'))
 
     # generate tpc-h data
-    tpch_path = '{}/tpch_2_13_0'.format(config.paths['tests-repo'])
+    tpch_path = '{}/tpch_2_13_0'.format(config.paths[config.TESTS_REPO])
     with cd(tpch_path):
         run('make')
         run('SCALE_FACTOR={} CHUNKS="o 24 c 4 P 1 S 4 s 1" sh generate2.sh'.format(scale))

--- a/fabfile/config.py
+++ b/fabfile/config.py
@@ -3,18 +3,32 @@ import os
 
 HOME_DIR = expanduser("~")
 
+CODE_DIRECTORY = 'code-directory'
+TESTS_REPO = 'tests-repo'
+CITUS_REPO = 'citus-repo'
+ENTERPRISE_REPO = 'enterprise-repo'
+PG_LATEST = 'pg-latest'
+PG_SOURCE_BALLS = 'pg-source-balls'
+HOME_DIRECTORY = 'home-directory'
+RESULTS_DIRECTORY = 'results-directory'
+CITUS_INSTALLATION = 'citus-installation'
+
+PG_VERSION = 'pg-version'
+PG_CONFIGURE_FLAGS = 'pg-configure-flags'
+
 paths = {
-    'code-directory': os.path.join(HOME_DIR, 'code'),
-    'tests-repo': os.path.join(HOME_DIR, 'test-automation'),
-    'citus-repo': os.path.join(HOME_DIR, 'citus'),
-    'enterprise-repo': os.path.join(HOME_DIR, 'citus-enterprise'),
-    'pg-latest': os.path.join(HOME_DIR, 'pg-latest'),
-    'pg-source-balls': os.path.join(HOME_DIR, 'postgres-source'),
-    'home-directory': HOME_DIR, 
-    'citus-installation': os.path.join(HOME_DIR, 'citus-installation')
+    CODE_DIRECTORY: os.path.join(HOME_DIR, 'code'),
+    TESTS_REPO: os.path.join(HOME_DIR, 'test-automation'),
+    CITUS_REPO: os.path.join(HOME_DIR, 'citus'),
+    ENTERPRISE_REPO: os.path.join(HOME_DIR, 'citus-enterprise'),
+    PG_LATEST: os.path.join(HOME_DIR, 'pg-latest'),
+    PG_SOURCE_BALLS: os.path.join(HOME_DIR, 'postgres-source'),
+    HOME_DIRECTORY: HOME_DIR, 
+    RESULTS_DIRECTORY: os.path.join(HOME_DIR, 'results'),
+    CITUS_INSTALLATION: os.path.join(HOME_DIR, 'citus-installation')
 }
 
 settings = {
-    'pg-version': '9.6.1',
-    'pg-configure-flags': ['--with-openssl'],
+    PG_VERSION: '9.6.1',
+    PG_CONFIGURE_FLAGS: ['--with-openssl'],
 }

--- a/fabfile/prefix.py
+++ b/fabfile/prefix.py
@@ -1,5 +1,5 @@
 '''
-$HOME/pg-latest (config.paths['pg-latest']) should always point to the
+$HOME/pg-latest (config.paths[config.PG_LATEST]) should always point to the
 installation of citus we're currently working with. This way tasks which interact with an
 installation can just use pg-latest and not care where it points to. (We use this instead
 of something like a "use" task because this is long-term state which should be kept
@@ -19,7 +19,7 @@ def set_prefix(prefix):
     if not os.path.isabs(prefix):
         abort('{} is not an absolute path'.format(prefix))
         
-    latest = config.paths['pg-latest']
+    latest = config.paths[config.PG_LATEST]
 
     # -f to overwrite any existing links
     # -n to not follow the {latest} link, if it exists, and instead replace it
@@ -28,7 +28,7 @@ def set_prefix(prefix):
 
 def ensure_pg_latest_exists(default):
     'If there is no valid working directory make one and point it at prefix'
-    latest = config.paths['pg-latest']
+    latest = config.paths[config.PG_LATEST]
 
     # make sure pg-latest exists
     if not exists(latest):
@@ -44,7 +44,7 @@ def ensure_pg_latest_exists(default):
 
 def check_for_pg_latest():
     "Fail-fast if there isn't a valid working directory"
-    latest = config.paths['pg-latest']
+    latest = config.paths[config.PG_LATEST]
 
     if not exists(latest):
         abort('There is no pg-latest symlink, run a setup.XXX task to create a cluster or the set_pg_latest task to point pg-latest to a citus installation')

--- a/fabfile/run.py
+++ b/fabfile/run.py
@@ -42,8 +42,11 @@ def pgbench_tests(config_file='pgbench_default.ini', connectionURI=''):
     config_folder_path = os.path.join(config.HOME_DIR, "test-automation/fabfile/pgbench_confs/")
     config_parser.read(config_folder_path + config_file)
 
+
     current_time_mark = time.strftime('%Y-%m-%d-%H-%M')
-    results_file = open(os.path.join(config.paths[config.HOME_DIRECTORY], 'pgbench_results_{}.csv'.format(current_time_mark)), 'w')
+    utils.mkdir_if_not_exists(config.paths[config.RESULTS_DIRECTORY])
+    path = os.path.join(config.paths[config.RESULTS_DIRECTORY], 'pgbench_results_{}_{}.csv'.format(current_time_mark, config_file))
+    results_file = open(path, 'w')
 
     use_enterprise = config_parser.get('DEFAULT', 'use_enterprise')
 
@@ -180,16 +183,17 @@ def tpch_automate(config_file='tpch_default.ini', connectionURI=''):
 
             execute(add.tpch, connectionURI= connectionURI, scale_factor=scale_factor)
             execute(tpch_queries, eval(config_parser.get(section, 'tpch_tasks_executor_types')), connectionURI,
-                    pg_version, citus_version)
+                    pg_version, citus_version, config_file)
             execute(pg.stop)
 
 
 @task
 @roles('master')
-def tpch_queries(query_info, connectionURI, pg_version, citus_version):
-    results_file = open(
-        os.path.join(config.paths[config.HOME_DIRECTORY],'tpch_benchmark_results_PG-{}_Citus-{}.txt'.format(pg_version, citus_version)),
-        'a')
+def tpch_queries(query_info, connectionURI, pg_version, citus_version, config_file):
+    utils.mkdir_if_not_exists(config.paths[config.RESULTS_DIRECTORY])
+    path = os.path.join(config.paths[config.RESULTS_DIRECTORY], 'tpch_benchmark_results_{}_PG-{}_Citus-{}.txt'.format(config_file, pg_version, citus_version))
+    results_file = open(path, 'a')
+
     psql = '{}/bin/psql'.format(config.paths[config.PG_LATEST])
     tpch_path = '{}/tpch_2_13_0/distributed_queries/'.format(config.paths[config.TESTS_REPO])
 

--- a/fabfile/run.py
+++ b/fabfile/run.py
@@ -29,7 +29,7 @@ def jdbc():
 @roles('master')
 def regression():
     'Runs Citus\' regression tests'
-    with cd(config.paths['citus-repo']):
+    with cd(config.paths[config.CITUS_REPO]):
         run('make check')
 
 
@@ -43,7 +43,7 @@ def pgbench_tests(config_file='pgbench_default.ini', connectionURI=''):
     config_parser.read(config_folder_path + config_file)
 
     current_time_mark = time.strftime('%Y-%m-%d-%H-%M')
-    results_file = open(os.path.join(config.paths['home-directory'], 'pgbench_results_{}.csv'.format(current_time_mark)), 'w')
+    results_file = open(os.path.join(config.paths[config.HOME_DIRECTORY], 'pgbench_results_{}.csv'.format(current_time_mark)), 'w')
 
     use_enterprise = config_parser.get('DEFAULT', 'use_enterprise')
 
@@ -188,10 +188,10 @@ def tpch_automate(config_file='tpch_default.ini', connectionURI=''):
 @roles('master')
 def tpch_queries(query_info, connectionURI, pg_version, citus_version):
     results_file = open(
-        os.path.join(config.paths['home-directory'],'tpch_benchmark_results_PG-{}_Citus-{}.txt'.format(pg_version, citus_version)),
+        os.path.join(config.paths[config.HOME_DIRECTORY],'tpch_benchmark_results_PG-{}_Citus-{}.txt'.format(pg_version, citus_version)),
         'a')
-    psql = '{}/bin/psql'.format(config.paths['pg-latest'])
-    tpch_path = '{}/tpch_2_13_0/distributed_queries/'.format(config.paths['tests-repo'])
+    psql = '{}/bin/psql'.format(config.paths[config.PG_LATEST])
+    tpch_path = '{}/tpch_2_13_0/distributed_queries/'.format(config.paths[config.TESTS_REPO])
 
     for query_code, executor_type in query_info:
         executor_string = "set citus.task_executor_type to '{}'".format(executor_type)

--- a/fabfile/use.py
+++ b/fabfile/use.py
@@ -21,7 +21,7 @@ def citus(*args):
         abort('You must provide a single argument, with a command such as "use.citus:v6.0.1"')
     git_ref = args[0]
 
-    path = config.paths['citus-repo']
+    path = config.paths[config.CITUS_REPO]
     local('rm -rf {} || true'.format(path))
     local('git clone -q https://github.com/citusdata/citus.git {}'.format(path))
     with lcd(path):
@@ -41,7 +41,7 @@ def enterprise(*args):
         abort('You must provide a single argument, with a command such as "use.enterprise:v6.0.1"')
     git_ref = args[0]
 
-    path = config.paths['enterprise-repo']
+    path = config.paths[config.ENTERPRISE_REPO]
     local('rm -rf {} || true'.format(path))
     local('git clone -q git@github.com:citusdata/citus-enterprise.git {}'.format(path))
     with lcd(path):
@@ -59,15 +59,15 @@ def postgres(*args):
         abort('You must provide a single argument. For example: "postgres:9.6.1"')
     version = args[0]
 
-    config.settings['pg-version'] = version
+    config.settings[config.PG_VERSION] = version
     utils.download_pg() # Check that this doesn't 404
 
 @task
 def asserts(*args):
     'Enable asserts in pg (and therefore citus) by passing --enable-cassert'
-    config.settings['pg-configure-flags'].append('--enable-cassert')
+    config.settings[config.PG_CONFIGURE_FLAGS].append('--enable-cassert')
 
 @task
 def debug_mode(*args):
     '''ps's configure is passed: '--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"' '''
-    config.settings['pg-configure-flags'].append('--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"')
+    config.settings[config.PG_CONFIGURE_FLAGS].append('--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"')

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -4,11 +4,17 @@ A grab bag of functions used by other modules
 
 import re
 import os.path
+import os
 
 from fabric.api import run, cd
 from fabric.contrib.files import append, exists
 
 import config
+
+
+def mkdir_if_not_exists(path):
+    if not os.path.exists(path):
+        os.mkdir(path)
 
 
 def rmdir(path, force=False):
@@ -17,14 +23,17 @@ def rmdir(path, force=False):
     if exists(path):
         run('rm {} -r {}'.format(flag, path))
 
+
 def psql(command, connectionURI=''):
     with cd(config.paths[config.PG_LATEST]):
         return run('bin/psql {} -c "{}"'.format(connectionURI, command))
+
 
 def add_github_to_known_hosts():
     'Removes prompts from github checkouts asking whether you want to trust the remote'
     key = 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
     append(os.path.join(config.HOME_DIR, '.ssh/known_hosts'), key)
+
 
 def download_pg():
     "Idempotent, does not download if file already exists. Returns the file's location"
@@ -41,6 +50,7 @@ def download_pg():
 
     run('wget -O {} --no-verbose {}'.format(target_file, url))
     return target_file
+
 
 def pg_url_for_version(version):
     return 'https://ftp.postgresql.org/pub/source/v{0}/postgresql-{0}.tar.bz2'.format(version)

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -18,7 +18,7 @@ def rmdir(path, force=False):
         run('rm {} -r {}'.format(flag, path))
 
 def psql(command, connectionURI=''):
-    with cd(config.paths['pg-latest']):
+    with cd(config.paths[config.PG_LATEST]):
         return run('bin/psql {} -c "{}"'.format(connectionURI, command))
 
 def add_github_to_known_hosts():
@@ -28,10 +28,10 @@ def add_github_to_known_hosts():
 
 def download_pg():
     "Idempotent, does not download if file already exists. Returns the file's location"
-    version = config.settings['pg-version']
+    version = config.settings[config.PG_VERSION]
     url = pg_url_for_version(version)
 
-    target_dir = config.paths['pg-source-balls']
+    target_dir = config.paths[config.PG_SOURCE_BALLS]
     run('mkdir -p {}'.format(target_dir))
 
     target_file = '{}/{}'.format(target_dir, os.path.basename(url))


### PR DESCRIPTION
This PR:
- refactors hard coded config variables
- puts config name to result file so that when looking at a result file we can understand which config was used
- creates a result folder to store all test results

Fixes #108.
Fixes #107.
Fixes #106.