### PR TITLE
Fix doing the same steps multiple times in setup

### DIFF
--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -22,6 +22,7 @@ import prefix
 __all__ = ["basic_testing", "tpch", "valgrind", "enterprise"]
 
 @task
+@roles('master')
 def basic_testing():
     'Sets up a no-frills Postgres+Citus cluster'
     execute(prefix.ensure_pg_latest_exists, default=config.CITUS_INSTALLATION)
@@ -30,6 +31,7 @@ def basic_testing():
     execute(add_workers)
 
 @task
+@roles('master')
 def tpch():
     'Just like basic_testing, but also includes some files useful for tpc-h'
     execute(prefix.ensure_pg_latest_exists, default=config.CITUS_INSTALLATION)


### PR DESCRIPTION
Currently setup steps are run "number of node" times, which means that if we have a cluster that has 20 nodes, and if we run the following command on coordinator:

```bash
fab use.postgres:11.5 use.citus:master setup.basic_testing
```

The `basic_testing` step will be run 20 times. And in each step we run all commands with `execute` function. The documentation from execute:

```
    The task will then be executed once per host in its host list, which is
    (again) assembled in the same manner as CLI-specified tasks: drawing from
    :option:`-H`, :ref:`env.hosts <hosts>`, the `~fabric.decorators.hosts` or
    `~fabric.decorators.roles` decorators, and so forth.
```

Which means that in each run of 20 times, we will be sending the commands to all the hosts. This means that we are running the command 19 times unnecessarily. To solve this we should run the basic_testing only from the coordinator, so we should add a role `@roles('master')`  to the task.

Fixes #118.
Fixes #55.

