### PR TITLE
fix path problem in pgbench custom scripts

### DIFF
--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -25,7 +25,7 @@ pgbench_command: pgbench -c 32 -j 32 -T 120 -P 5 -n -f fabfile/pgbench_scripts/d
 
 [copy_test]
 sql_command: COPY (SELECT generate_series(1,10000), (random() * 32767)::int, (random() * 32767)::int, (random() * 32767)::int) TO '${HOME}/test_data.csv';
-pgbench_command: pgbench -c 32 -j 16 -T 120 -P 5 -n -f fabfile/pgbench_scripts/copy.sql
+pgbench_command: pgbench -c 32 -j 16 -T 120 -P 5 -n -f fabfile/pgbench_scripts/copy.sql-D HOME=${HOME}
 
 [generate_series_test]
 pgbench_command: pgbench -c 32 -j 16 -f -T 120 -P 5 -n  fabfile/pgbench_scripts/generate_series.sql

--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -55,10 +55,10 @@ pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql
+pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25
+pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
 
 [mix_them_all]
 pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
@@ -68,4 +68,5 @@ pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
     -f fabfile/pgbench_scripts/realtime_select.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_pushdown.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_coordinator.sql@1 \
-    -f fabfile/pgbench_scripts/scale_copy.sql@1
+    -f fabfile/pgbench_scripts/scale_copy.sql@1 \
+    -D HOME=${HOME}

--- a/fabfile/pgbench_confs/scale_test_no_index.ini
+++ b/fabfile/pgbench_confs/scale_test_no_index.ini
@@ -43,10 +43,10 @@ pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql
+pgbench_command: pgbench -c8 -j8  -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25
+pgbench_command: pgbench -c16 -j8  -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25  -D HOME=${HOME}
 
 [mix_them_all]
 pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
@@ -56,4 +56,5 @@ pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
     -f fabfile/pgbench_scripts/realtime_select.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_pushdown.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_coordinator.sql@1 \
-    -f fabfile/pgbench_scripts/scale_copy.sql@1
+    -f fabfile/pgbench_scripts/scale_copy.sql@1 \
+    -D HOME=${HOME}

--- a/fabfile/pgbench_confs/scale_test_prepared.ini
+++ b/fabfile/pgbench_confs/scale_test_prepared.ini
@@ -55,10 +55,10 @@ pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -M prepared
+pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -M prepared -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql@25  -M prepared
+pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql@25  -M prepared  -D HOME=${HOME}
 
 [mix_them_all]
 pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r  -M prepared \
@@ -68,4 +68,5 @@ pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r  -M prepared \
     -f fabfile/pgbench_scripts/realtime_select.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_pushdown.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_coordinator.sql@1 \
-    -f fabfile/pgbench_scripts/scale_copy.sql@1
+    -f fabfile/pgbench_scripts/scale_copy.sql@1 \
+    -D HOME=${HOME}

--- a/fabfile/pgbench_confs/scale_test_reference.ini
+++ b/fabfile/pgbench_confs/scale_test_reference.ini
@@ -55,10 +55,10 @@ pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/i
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql
+pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25
+pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
 
 [mix_them_all]
 pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r \
@@ -68,4 +68,5 @@ pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r \
     -f fabfile/pgbench_scripts/realtime_select.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_pushdown.sql@1 \
     -f fabfile/pgbench_scripts/insert_select_coordinator.sql@1 \
-    -f fabfile/pgbench_scripts/scale_copy.sql@1
+    -f fabfile/pgbench_scripts/scale_copy.sql@1 \
+    -D HOME=${HOME}

--- a/fabfile/pgbench_scripts/copy.sql
+++ b/fabfile/pgbench_scripts/copy.sql
@@ -1,1 +1,1 @@
-COPY test_table FROM '${HOME}/test_data.csv';
+COPY test_table FROM ':HOME/scale_test_data.csv';

--- a/fabfile/pgbench_scripts/scale_copy.sql
+++ b/fabfile/pgbench_scripts/scale_copy.sql
@@ -1,1 +1,1 @@
-COPY test_table FROM '${HOME}/scale_test_data.csv';
+COPY test_table FROM ':HOME/scale_test_data.csv';


### PR DESCRIPTION
It seems that we cannot use path variables inside pgbench. We can pass a variable from the command. This PR fixes that.

Before we supported Azure, the path of csv file was hard coded in the sql file. After adding the Azure support we had to remove the hard coded path, because it is not the same in azure and aws. It seems that we cannot access the environment variables in the sql file. We can pass an argument with pgbench `-D` option though. 
