### PR TITLE
remove hard coded value in procedure call

### DIFF
--- a/generateRandomQueries/generate_procedure.py
+++ b/generateRandomQueries/generate_procedure.py
@@ -102,7 +102,7 @@ def generate_procedures(procedure_count, table_names, file):
 def generate_procedure_calls(procedure_count, file):
     call_amount = random.randint(1, MAX_CALL_AMOUNT)
     for i in range (0, call_amount):
-        value = random.randint(1, 100)
+        value = random.randint(0, MAX_TABLE_ROWS-1)
         procedure_index = random.randint(0, procedure_count-1)
         current_call = PROCEDURE_CALL_SQL.format(procedure_index, value)
         for i in range(0, REPEAT_AMOUNT):


### PR DESCRIPTION
Generated table have sizes between MIN_TABLE_ROWS and MAX_TABLE_ROWS. However we are calling the procedures with only values 0-100, which is a hard coded value. It makes more sense to call it with values up to MAX_TABLE_ROWS. 