### PR TITLE
use proximity placement groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,11 +240,11 @@ After you are done with testing, you can delete the resource group with:
 Currently the default time for tests 300 seconds, and as we have many tests it might take a while to run all the tests. So when testing a change, it is better to change the test times to something short such as 5 seconds. The time can be changed with the -T parameter:
 
 ```bash
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r
 
 ->
 
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ You can find your test results in https://github.com/citusdata/release-test-resu
 By default the tests will be run against `enterprise-master` and the latest released version. If you want to test on a custom branch you should change the config files of relevant tests with your custom branch name in:
 
 ```text
-postgres_citus_versions: [('12.1', 'your-custom-branch-name-in-enterprise'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'your-custom-branch-name-in-enterprise'), ('12.1', 'release-9.2')]
 ```
 
 You can change all the settings in these files, the config files for tests are located at:

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -127,7 +127,8 @@
         "subnetPrefix": "10.192.0.0/24",
         "publicIPAddressType": "Static",
         "publicIPAddressName": "citusPublicIP",
-        "numberOfInstances":"[add(parameters('numberOfWorkers'), 1)]"
+        "numberOfInstances":"[add(parameters('numberOfWorkers'), 1)]",
+        "ppgName": "citusPPG"
     },
     "resources": [
         {
@@ -156,6 +157,15 @@
                     },
                     "keySource": "Microsoft.Storage"
                 }
+            }
+        },
+        {
+            "apiVersion": "2019-03-01",
+            "type": "Microsoft.Compute/proximityPlacementGroups",
+            "name": "[variables('ppgName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                
             }
         },
         {
@@ -288,17 +298,21 @@
         },
         {
             "type": "Microsoft.Compute/virtualMachines",
-            "apiVersion": "2016-04-30-preview",
+            "apiVersion": "2018-06-01",
             "name": "[concat(parameters('clusterName'), 'vm', copyIndex())]",
             "location": "[parameters('location')]",
             "dependsOn": [
                 "nicLoop",
+                "[concat('Microsoft.Compute/proximityPlacementGroups/', variables('ppgName'))]",
                 "[resourceId('Microsoft.Compute/disks/', concat(parameters('clusterName'), 'datadisk', copyIndex()))]",
                 "[resourceId('Microsoft.Storage/storageAccounts/', variables('storageAcctName'))]"
             ],
             "properties": {
                 "hardwareProfile": {
                     "vmSize": "[if(equals(copyindex(),0), parameters('coordinatorVmSize'), parameters('workerVmSize'))]"
+                },
+                "proximityPlacementGroup": {
+                    "id": "[resourceId('Microsoft.Compute/proximityPlacementGroups',variables('ppgName'))]"
                 },
                 "osProfile": {
                     "computerName": "[concat(parameters('clusterName'), 'vm', copyIndex())]",

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -7,6 +7,22 @@ set -e
 # echo commands
 set -x
 
+ssh_execute() {
+   ip=$1
+   shift;
+   command=$@
+   n=0
+   until [ $n -ge 4 ]
+   do
+      sh ./delete-security-rule.sh
+      ssh -o "StrictHostKeyChecking no" -A pguser@${ip} "source ~/.bash_profile;${command}" && break
+      n=$[$n+1]
+   done
+
+   if [ $n == 4 ]; then
+      exit 1
+   fi
+}
 
 function cleanup {
     sh ./delete-resource-group.sh
@@ -29,8 +45,8 @@ chmod 600 ~/.ssh/known_hosts
 sh ./delete-security-rule.sh
 
 echo "adding public ip to known hosts in remote"
-ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"
+ssh_execute ${public_ip} "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"
 echo "running tests in remote"
 # ssh with non-interactive mode does not source bash profile, so we will need to do it ourselves here.
-ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} "source ~/.bash_profile;/home/pguser/test-automation/azure/run-all-tests.sh ${rg}"
+ssh_execute ${public_ip} "source ~/.bash_profile;/home/pguser/test-automation/azure/run-all-tests.sh ${rg}"
 

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -7,6 +7,9 @@ set -e
 # echo commands
 set -x
 
+# ssh_execute tries to send the given command over the given connection multiple times.
+# Before sending the command it deletes the security rule on azure. Sometimes the rule
+# comes back too quick, so we get a timeout, that is why we try multiple times.
 ssh_execute() {
    ip=$1
    shift;

--- a/fabfile/pgbench_confs/pgbench_cloud.ini
+++ b/fabfile/pgbench_confs/pgbench_cloud.ini
@@ -26,10 +26,10 @@ sql_command: SELECT create_distributed_table('pgbench_tellers', 'tid');
 sql_command: VACUUM ANALYZE pgbench_tellers;
 
 [default-pgbench]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r
 
 [simple-update]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -b simple-update
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -b simple-update
 
 [select-only]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -b select-only
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -b select-only

--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",
@@ -30,10 +30,10 @@ distribute_table_command: SELECT create_distributed_table('pgbench_tellers', 'ti
 sql_command: VACUUM ANALYZE pgbench_tellers;
 
 [default-pgbench]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r
 
 [simple-update]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -b simple-update
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -b simple-update
 
 [select-only]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -b select-only
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -b select-only

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",
@@ -30,10 +30,10 @@ distribute_table_command: SELECT create_distributed_table('pgbench_tellers', 'ti
 sql_command: VACUUM ANALYZE pgbench_tellers;
 
 [default-pgbench]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -f fabfile/pgbench_scripts/pgbench_default_no_transactions.sql
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -f fabfile/pgbench_scripts/pgbench_default_no_transactions.sql
 
 [simple-update]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -f fabfile/pgbench_scripts/pgbench_simple_update_no_transactions.sql
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -f fabfile/pgbench_scripts/pgbench_simple_update_no_transactions.sql
 
 [select-only]
-pgbench_command: pgbench -c 32 -j 16 -T 300 -P 10 -r -f fabfile/pgbench_scripts/pgbench_select_only_no_transactions.sql
+pgbench_command: pgbench -c 32 -j 16 -T 600 -P 10 -r -f fabfile/pgbench_scripts/pgbench_select_only_no_transactions.sql

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '1GB'",

--- a/fabfile/pgbench_confs/pgbench_issue_1799.ini
+++ b/fabfile/pgbench_confs/pgbench_issue_1799.ini
@@ -20,7 +20,7 @@ sql_command: CREATE TABLE test_table (key int, occurred_at timestamp DEFAULT now
 distribute_table_command: SELECT create_distributed_table('test_table', 'key');
 
 [insert_test]
-pgbench_command: pgbench -c128 -j128 -T 3000 -P 1 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
+pgbench_command: pgbench -c128 -j128 -T 6000 -P 1 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
 
 [select_test]
-pgbench_command: pgbench -c32 -j32 -T 30012 -P 1 -n -r -f fabfile/pgbench_scripts/select_all_with_limit.sql
+pgbench_command: pgbench -c32 -j32 -T 60012 -P 1 -n -r -f fabfile/pgbench_scripts/select_all_with_limit.sql

--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",
@@ -34,34 +34,34 @@ sql_command: CREATE INDEX i4 ON test_table(value_2); CREATE INDEX i5 ON test_tab
 sql_command: CREATE INDEX i6 ON test_table USING GIST(value_3);
 
 [single_insert]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
 
 [muti_row_insert]
-pgbench_command: pgbench -c32 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
+pgbench_command: pgbench -c32 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
 
 [router_select]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
 
 [realtime_select]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
 
 [insert_select_pushdown]
 sql_command: CREATE TABLE test_table_target (key int, occurred_at timestamp DEFAULT now(), value_1 jsonb, value_2 text[], value_3 int4range, value_4 complex NOT NULL);
 distribute_table_command: SELECT create_distributed_table('test_table_target', 'key');
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
 
 [insert_select_coordinator]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
+pgbench_command: pgbench -c8 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
 
 [mix_them_all]
-pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
+pgbench_command: pgbench -c8 -j4 -T 600 -P 10 -n -r \
     -f fabfile/pgbench_scripts/insert_complex.sql@5 \
     -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@5 \
     -f fabfile/pgbench_scripts/router_select.sql@5 \

--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_100_columns.ini
+++ b/fabfile/pgbench_confs/scale_test_100_columns.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_100_columns.ini
+++ b/fabfile/pgbench_confs/scale_test_100_columns.ini
@@ -29,4 +29,4 @@ sql_command: CREATE TABLE test_table (key int, value_1 int, value_2 int, value_3
 distribute_table_command: SELECT create_distributed_table('test_table', 'key');
 
 [single_insert]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert.sql

--- a/fabfile/pgbench_confs/scale_test_foreign.ini
+++ b/fabfile/pgbench_confs/scale_test_foreign.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_foreign.ini
+++ b/fabfile/pgbench_confs/scale_test_foreign.ini
@@ -20,7 +20,7 @@ sql_command: CREATE TABLE test_table_referencing (key int REFERENCES test_table 
 distribute_table_command: SELECT create_distributed_table('test_table_referencing', 'key');
 
 [single_insert]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_foreign.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_foreign.sql
 
 [muti_row_insert]
-pgbench_command: pgbench -c32 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/multi_row_insert_foreign.sql
+pgbench_command: pgbench -c32 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/multi_row_insert_foreign.sql

--- a/fabfile/pgbench_confs/scale_test_no_index.ini
+++ b/fabfile/pgbench_confs/scale_test_no_index.ini
@@ -22,34 +22,34 @@ sql_command: CREATE TABLE test_table (key int, occurred_at timestamp DEFAULT now
 distribute_table_command: SELECT create_distributed_table('test_table', 'key');
 
 [single_insert]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
 
 [muti_row_insert]
-pgbench_command: pgbench -c32 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
+pgbench_command: pgbench -c32 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
 
 [router_select]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
 
 [realtime_select]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
 
 [insert_select_pushdown]
 sql_command: CREATE TABLE test_table_target (key int, occurred_at timestamp DEFAULT now(), value_1 jsonb, value_2 text[], value_3 int4range, value_4 complex NOT NULL);
 distribute_table_command: SELECT create_distributed_table('test_table_target', 'key');
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
 
 [insert_select_coordinator]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
+pgbench_command: pgbench -c8 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25  -D HOME=${HOME}
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25  -D HOME=${HOME}
 
 [mix_them_all]
-pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r \
+pgbench_command: pgbench -c8 -j4 -T 600 -P 10 -n -r \
     -f fabfile/pgbench_scripts/insert_complex.sql@5 \
     -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@5 \
     -f fabfile/pgbench_scripts/router_select.sql@5 \

--- a/fabfile/pgbench_confs/scale_test_no_index.ini
+++ b/fabfile/pgbench_confs/scale_test_no_index.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_prepared.ini
+++ b/fabfile/pgbench_confs/scale_test_prepared.ini
@@ -34,34 +34,34 @@ sql_command: CREATE INDEX i4 ON test_table(value_2); CREATE INDEX i5 ON test_tab
 sql_command: CREATE INDEX i6 ON test_table USING GIST(value_3);
 
 [single_insert]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex_prepared.sql -M prepared
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex_prepared.sql -M prepared
 
 [muti_row_insert]
-pgbench_command: pgbench -c32 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql -M prepared
+pgbench_command: pgbench -c32 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql -M prepared
 
 [router_select]
-pgbench_command: pgbench -c128 -j16 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql -M prepared
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql -M prepared
 
 [realtime_select]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql -M prepared
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql -M prepared
 
 [insert_select_pushdown]
 sql_command: CREATE TABLE test_table_target (key int, occurred_at timestamp DEFAULT now(), value_1 jsonb, value_2 text[], value_3 int4range, value_4 complex);
 distribute_table_command: SELECT create_distributed_table('test_table_target', 'key');
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql -M prepared
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql -M prepared
 
 [insert_select_coordinator]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql -M prepared
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql -M prepared
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c8 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -M prepared -D HOME=${HOME}
+pgbench_command: pgbench -c8 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -M prepared -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c16 -j8 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql@25  -M prepared  -D HOME=${HOME}
+pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql@25  -M prepared  -D HOME=${HOME}
 
 [mix_them_all]
-pgbench_command: pgbench -c8 -j4 -T 300 -P 10 -n -r  -M prepared \
+pgbench_command: pgbench -c8 -j4 -T 600 -P 10 -n -r  -M prepared \
     -f fabfile/pgbench_scripts/insert_complex_prepared.sql@5 \
     -f fabfile/pgbench_scripts/multi_row_insert_prepared.sql@5 \
     -f fabfile/pgbench_scripts/router_select.sql@5 \

--- a/fabfile/pgbench_confs/scale_test_prepared.ini
+++ b/fabfile/pgbench_confs/scale_test_prepared.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/pgbench_confs/scale_test_reference.ini
+++ b/fabfile/pgbench_confs/scale_test_reference.ini
@@ -34,34 +34,34 @@ sql_command: CREATE INDEX i4 ON test_table(value_2); CREATE INDEX i5 ON test_tab
 sql_command: CREATE INDEX i6 ON test_table USING GIST(value_3);
 
 [single_insert]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
 
 [muti_row_insert]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
 
 [router_select]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
 
 [realtime_select]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
 
 [insert_select_pushdown]
 sql_command: CREATE TABLE test_table_target (key int, occurred_at timestamp DEFAULT now(), value_1 jsonb, value_2 text[], value_3 int4range, value_4 complex NOT NULL);
 distribute_table_command: SELECT create_distributed_table('test_table_target', 'key');
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
 
 [insert_select_coordinator]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql -D HOME=${HOME}
 
 [copy_and_multi_row]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
 
 [mix_them_all]
-pgbench_command: pgbench -c4 -j4 -T 300 -P 10 -n -r \
+pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r \
     -f fabfile/pgbench_scripts/insert_complex.sql@5 \
     -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@5 \
     -f fabfile/pgbench_scripts/router_select.sql@5 \

--- a/fabfile/pgbench_confs/scale_test_reference.ini
+++ b/fabfile/pgbench_confs/scale_test_reference.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '5GB'",

--- a/fabfile/tpch_confs/tpch_default.ini
+++ b/fabfile/tpch_confs/tpch_default.ini
@@ -1,6 +1,6 @@
 [test]
 use_enterprise: on
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
 tpch_tasks_executor_types: [('1.sql', 'real-time'), ('3.sql', 'task-tracker'), ('5.sql', 'task-tracker'), ('6.sql', 'real-time')
                             ,('7.sql', 'task-tracker'), ('8.sql', 'task-tracker'), ('9.sql', 'task-tracker'), ('10.sql', 'task-tracker')
                             , ('12.sql', 'real-time'), ('14.sql', 'task-tracker'), ('19.sql', 'task-tracker')]

--- a/fabfile/tpch_confs/tpch_default.ini
+++ b/fabfile/tpch_confs/tpch_default.ini
@@ -1,6 +1,6 @@
 [test]
 use_enterprise: on
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.1')]
+postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 tpch_tasks_executor_types: [('1.sql', 'real-time'), ('3.sql', 'task-tracker'), ('5.sql', 'task-tracker'), ('6.sql', 'real-time')
                             ,('7.sql', 'task-tracker'), ('8.sql', 'task-tracker'), ('9.sql', 'task-tracker'), ('10.sql', 'task-tracker')
                             , ('12.sql', 'real-time'), ('14.sql', 'task-tracker'), ('19.sql', 'task-tracker')]


### PR DESCRIPTION
This PR:
- Adds proximity placement groups to ARM template so that VMs will be deployed within the same data center.
- Changes default test times from 300 seconds to 600 seconds.
- Makes running `ssh` more resilient to timeouts by trying to run a command over ssh multiple times.

Fixes #139.
Fixes #145.
