### PR TITLE
run enterprise setup from only coordinator

### DIFF
--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -56,6 +56,7 @@ def valgrind():
     execute(add_workers)
 
 @task
+@roles('master')
 def enterprise():
     'Installs the enterprise version of Citus'
     execute(prefix.ensure_pg_latest_exists, default=config.CITUS_INSTALLATION)


### PR DESCRIPTION
`enterprise` is a task , which means it will be executed in all the nodes. However inside `enterprise` everything is executed with `execute` which means the called functions will be executed multiple times. This is a problem when we use `fab setup.enterprise`.

Note that directly calling `enterprise` method will not run this on every node. This is only triggered when either:
- we call this with fab command: `fab setup.enterprise`
- or we call this with `execute` method from fab.

