### PR TITLE
install cmake

### DIFF
--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,6 +17,17 @@ python get-pip.py
 # install git to clone the repository
 yum install -y git screen
 
+# install epel release
+rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+
+#install python3
+yum -y install https://centos7.iuscommunity.org/ius-release.rpm
+yum -y install python36u
+
+#install cmake3
+yum install cmake3 -y
+ln -s `which cmake3` /usr/bin/cmake
+
 # this is the username in our instances
 TARGET_USER=pguser
 


### PR DESCRIPTION
With the latest changes to our citus repository, we require cmake during `make`, this PR adds that.

We specifically need cmake3, which requires python3, so they are added as well.
