### PR TITLE
use master branch by default in hammerdb

### DIFF
--- a/fabfile/hammerdb_confs/master.ini
+++ b/fabfile/hammerdb_confs/master.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_version: ('12.1', 'release-9.2')
+postgres_citus_version: ('12.1', 'master')
 postgresql_conf: [
     # the following two are necessary to prevent getting timeouts, do not change them.
     "tcp_keepalives_idle = 120",


### PR DESCRIPTION
We want to see the performance against master most of the time, so it
makes sense to use master by default. During regression tests we can
manually set the branches for release branches.