### PR TITLE
change some default hammerdb benchmark settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ After adding the configs `fabfile/hammerdb_confs` could look like:
 Note that running a benchmark with a single config file with a vuuser of 150 and 1M iterations could
 take around 3-4 hours. (the whole process)
 
-If you want to run only the tpcc benchmark or the analytical queries, you should change the `is_tpcc` and `is_ch` variables in `create-run.sh`. For example if you want to run only tpcc benchmarks, you should set `is_tpcc` to `true` and `is_ch` to `false`. When you are only running the analytical queries, you can also specify how long you want them to be run by changing the `DEFAULT_CH_RUNTIME_IN_SECS` variable in `build-and-run.sh`. By default it will be run 1800 seconds.
+If you want to run only the tpcc benchmark or the analytical queries, you should change the `is_tpcc` and `is_ch` variables in `create-run.sh`. For example if you want to run only tpcc benchmarks, you should set `is_tpcc` to `true` and `is_ch` to `false` (Alternatively you can see `IS_CH` and `IS_TPCC` environment variables). When you are only running the analytical queries, you can also specify how long you want them to be run by changing the `DEFAULT_CH_RUNTIME_IN_SECS` variable in `build-and-run.sh`. By default it will be run 1800 seconds.
 
 You can change the thread count and initial sleep time for analytical queries from `build-and-run.sh` with `CH_THREAD_COUNT` and `RAMPUP_TIME` variables respectively.
 

--- a/hammerdb/azuredeploy.parameters.json
+++ b/hammerdb/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "numberOfWorkers": {
-            "value": 4
+            "value": 10
         },
         "diskType": {
             "value": "Premium_LRS"

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -7,8 +7,8 @@ set -e
 # echo commands
 set -x
 
-is_tpcc=true # set to true if you want tpcc to be run, otherwise set to false
-is_ch=true # set to true if you want ch benchmark to be run, otherwise set to false
+is_tpcc=${IS_TPCC:=true} # set to true if you want tpcc to be run, otherwise set to false
+is_ch=${IS_CH:=true} # set to true if you want ch benchmark to be run, otherwise set to false
 username=pguser # username of the database
 hammerdb_version=3.3
 

--- a/hammerdb/create.sh
+++ b/hammerdb/create.sh
@@ -35,11 +35,10 @@ branch_name=$(git symbolic-ref -q HEAD)
 branch_name=${branch_name##refs/heads/}
 branch_name=${branch_name:-HEAD}
 
-# if this is run on a job, use the branch for the job, otherwise use the local(running in local or remote without a job)
 # store the branch name in a file so that target user can read it. Target user cannot see the envionment variables because
 # we use login option in su and -p(preserving environment variables) cannot be used with login. We need to use login option
 # so that $HOME, $PATH are set to the target users $HOME and $PATH.
-export BRANCH=${CIRCLE_BRANCH:=$branch_name}
+export BRANCH=${branch_name}
 
 az group deployment create -g "${rg}" --template-file azuredeploy.json --parameters @azuredeploy.parameters.json --parameters sshPublicKey="${public_key}" branchName="$BRANCH" git_username="${GIT_USERNAME}" git_token="${GIT_TOKEN}"
 

--- a/hammerdb/run.tcl
+++ b/hammerdb/run.tcl
@@ -19,7 +19,7 @@ diset tpcc pg_defaultdbase pguser
 diset tpcc pg_storedprocs true
 diset tpcc pg_driver timed
 diset tpcc pg_rampup 3
-diset tpcc pg_duration 200
+diset tpcc pg_duration 60
 diset tpcc pg_timeprofile false
 diset tpcc pg_allwarehouse true
 diset tpcc pg_keyandthink false


### PR DESCRIPTION
When we want to see the performance change of a branch we should use a
10 node cluster, using 4 node cluster will not give us the results we
want to see.

The default runtime was 200 mins, which is too long. Running for 20-30
mins already gives us the results we want to see, so changing the
default from 200 to 25 makes sense.

IS_TPCC and IS_CH environment variables are added.