### PR TITLE
Add a script that replaces the branch names and pg version

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,16 @@
+
+# Usage of update_files.sh
+
+If you will test a custom branch, you can update all the config files with `./update_files.sh`. Say that you 
+will do the release testing for `release-9.2` and `release-9.3`. You can do the following:
+
+```bash
+vim update_files.sh
+
+new_branch1=release-9.3
+new_branch2=release-9.2
+new_pg_version=12.2
+
+./update_files.sh # this will update all the branches correctly
+git diff #make sure that everything is fine
+```

--- a/release/update_files.sh
+++ b/release/update_files.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# fail if trying to reference a variable that is not set.
+set -u
+# exit immediately if a command fails
+set -e
+# echo commands
+set -x
+
+## VARIABLES ##
+new_branch1=release-9.3
+new_branch2=release-9.2
+new_pg_version=12.2
+## VARIABLES ##
+
+releasedir="${0%/*}"
+cd ${releasedir}/.. # topdir
+# replace all .ini config files:
+# postgres_citus_versions: [('<pg_version>', '<branch_name>'), ('<pg_version>', '<branch_name2>')]
+# postgres_citus_versions: [('<new_pg_version>', '<new_branch1>'), ('<new_pg_version>', '<new_branch2>')]
+find . -type f -name "*.ini" |
+    xargs sed -i "s@postgres_citus_versions: \[('[^,;]\+', '[^,;]\+'), ('[^,;]\+', '[^,;]\+')\]@postgres_citus_versions: \[('${new_pg_version}', '${new_branch1}'), ('${new_pg_version}', '${new_branch2}')\]@g"
+# replace all .ini config files:
+# postgres_citus_versions: [('<pg_version>', '<branch_name>')]
+# postgres_citus_versions: [('<new_pg_version>', '<new_branch1>')]
+find . -type f -name "*.ini" | 
+    xargs sed -i "s@postgres_citus_versions: \[('[^,;]\+', '[^,;]\+')\]@postgres_citus_versions: \[('${new_pg_version}', '${new_branch1}')\]@g"


### PR DESCRIPTION
It is error prone to manually replace branch names in all files. As a solution to that, I have written a script which can be used to update files automatically, an example usage:

```
vim update_files.sh

new_branch1=release-9.3
new_branch2=release-9.2
new_pg_version=12.2

./update_files.sh # this will update all the branches correctly
git diff #make sure that everything is fine
```

