### PR TITLE
Use ssh or https to clone enterprise

### DIFF
--- a/fabfile/config.py
+++ b/fabfile/config.py
@@ -1,6 +1,7 @@
 from os.path import expanduser
 import os
 
+IS_SSH_KEYS_USED ='is_ssh_keys_used'
 HOME_DIR = expanduser("~")
 
 CODE_DIRECTORY = os.path.join(HOME_DIR, 'code')
@@ -17,5 +18,5 @@ PG_VERSION = '9.6.1'
 PG_CONFIGURE_FLAGS = ['--with-openssl']
 
 settings = {
-
+    IS_SSH_KEYS_USED: True
 }

--- a/fabfile/use.py
+++ b/fabfile/use.py
@@ -43,7 +43,10 @@ def enterprise(*args):
 
     path = config.ENTERPRISE_REPO
     local('rm -rf {} || true'.format(path))
-    local('git clone -q https://github.com/citusdata/citus-enterprise.git {}'.format(path))
+    if config.settings[config.IS_SSH_KEYS_USED]:
+        local('git clone -q git@github.com:citusdata/citus-enterprise.git {}'.format(path))
+    else:
+        local('git clone -q https://github.com/citusdata/citus-enterprise.git {}'.format(path))
     with lcd(path):
         local('git checkout {}'.format(git_ref))
     local('rm -rf {} || true'.format(path))
@@ -61,6 +64,11 @@ def postgres(*args):
 
     config.PG_VERSION = version
     utils.download_pg() # Check that this doesn't 404
+
+@task
+def hammerdb(*args):
+    # we use git tokens for authentication in hammerdb
+    config.settings[config.IS_SSH_KEYS_USED] = False
 
 @task
 def asserts(*args):


### PR DESCRIPTION
In test automation we use ssh keys to download enteprise, in hammerdb we
use git tokens to download enterprise. This PR stores that in our config
so that we can use the right method in both of them.

fixes #158.