### PR TITLE
Improve the default values for scale testing

### DIFF
--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -37,21 +37,21 @@ sql_command: CREATE INDEX i6 ON test_table USING GIST(value_3);
 pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_complex.sql
 
 [muti_row_insert]
-pgbench_command: pgbench -c32 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_multi_row_insert.sql
 
 [router_select]
 pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/router_select.sql
 
 [realtime_select]
-pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/realtime_select.sql
 
 [insert_select_pushdown]
 sql_command: CREATE TABLE test_table_target (key int, occurred_at timestamp DEFAULT now(), value_1 jsonb, value_2 text[], value_3 int4range, value_4 complex NOT NULL);
 distribute_table_command: SELECT create_distributed_table('test_table_target', 'key');
-pgbench_command: pgbench -c4 -j4 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_pushdown.sql
 
 [insert_select_coordinator]
-pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/insert_select_coordinator.sql
 
 [copy]
 sql_command: COPY (SELECT * FROM test_table LIMIT 100) TO '${HOME}/scale_test_data.csv';
@@ -61,7 +61,7 @@ pgbench_command: pgbench -c8 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/s
 pgbench_command: pgbench -c16 -j8 -T 600 -P 10 -n -r -f fabfile/pgbench_scripts/scale_copy.sql@1 -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@25 -D HOME=${HOME}
 
 [mix_them_all]
-pgbench_command: pgbench -c8 -j4 -T 600 -P 10 -n -r \
+pgbench_command: pgbench -c128 -j16 -T 600 -P 10 -n -r \
     -f fabfile/pgbench_scripts/insert_complex.sql@5 \
     -f fabfile/pgbench_scripts/scale_multi_row_insert.sql@5 \
     -f fabfile/pgbench_scripts/router_select.sql@5 \


### PR DESCRIPTION
As Citus should be able to handle a lot more concurrent queries
as of 9.3, we should increase the defaults.

Max connections is  already `1000` which is more than we need.