### PR TITLE
Increase default cores from 4 to 16

### DIFF
--- a/azure/azuredeploy.parameters.json
+++ b/azure/azuredeploy.parameters.json
@@ -9,10 +9,10 @@
             "value": "Premium_LRS"
         },
         "coordinatorVmSize": {
-            "value": "Standard_D4s_v3"
+            "value": "Standard_D16s_v3"
         },
         "workerVmSize": {
-            "value": "Standard_E4s_v3"
+            "value": "Standard_E16s_v3"
         },
         "coordinatorDiskSizeGB": {
             "value": 512


### PR DESCRIPTION
We already have a structure to automatically delete a resource group
once tests are done. When someone manually creates a cluster 4 cores
will probably not be that useful as well.