### PR TITLE
Force kill postgres process

### DIFF
--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -126,7 +126,7 @@ def total_memory_in_gb():
 @parallel
 def common_setup(build_citus_func):
     with hide('stdout'):
-        run('pkill postgres || true')
+        run('pkill -9 postgres || true')
 
     prefix.check_for_pg_latest()
     # empty it but don't delete the link


### PR DESCRIPTION
It seems that sometimes removing the postgres directory fails, it is
probably because postgres process is still running and therefore we
cannot remove the directory. We send a kill signal to postgres but it
might sometimes fail I guess. Therefore sending a force kill signal
seems a better option.

Fixes #160.