### PR TITLE
not retry if not ssh error

### DIFF
--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -19,6 +19,11 @@ ssh_execute() {
    do
       sh ./delete-security-rule.sh
       ssh -o "StrictHostKeyChecking no" -A pguser@${ip} "source ~/.bash_profile;${command}" && break
+      rc=$? # get return code
+      if [ $rc -ne 255 ] ; then
+         # if the error code is not 255 we didn't get a connection error.
+         exit 1
+      fi
       n=$[$n+1]
    done
 


### PR DESCRIPTION
If we get an error while running the actual scripts, we shouldn't retry them. We should only retry ssh connection errors, in which case 255 will be the returned value.