### PR TITLE
Disable deadlock prevention in hammerdb config

### DIFF
--- a/fabfile/hammerdb_confs/master.ini
+++ b/fabfile/hammerdb_confs/master.ini
@@ -18,6 +18,7 @@ postgresql_conf: [
     "citus.enable_repartition_joins = 'on'",
     "effective_io_concurrency = 128",
     "citus.shard_count = 60",
-    "track_io_timing = 'off'"
+    "track_io_timing = 'off'",
+    "citus.enable_deadlock_prevention = 'off'"
     ]
 use_enterprise: off


### PR DESCRIPTION
With the latest hammerdb changes (4.0), there are multi-shard updates.
Citus will use ShareUpdateExclusiveLock lock mode instead of
RowExclusiveLock if deadlock prevention is enabled. The locks are local
therefore there is not point in this prevention unless the updates are
always done from the same node. Ideally we should disable it only on the
workers but we currently don't have that structure in test automation
hence for hammerdb we will disable it in the cluster.