### PR TITLE
Add a job to delete resource group for hammerdb automatically

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,36 @@ jobs:
             ./add-sshkey.sh
             ./citus-bot.sh citusbot_tpch_test_resource_group
           name: install dependencies and run tpch tests
-          no_output_timeout: 10m         
+          no_output_timeout: 10m   
+
+  delete_resource_group:
+    docker:
+      - image: buildpack-deps:buster
+    working_directory: /home/circleci/project  
+    steps:
+      - azure-cli/install
+      - azure-cli/login-with-service-principal
+      - checkout
+      - run:
+          command: |
+            cd ./azure
+            ./delete-resource-group-job.sh
+          name: delete the given resource group
+          no_output_timeout: 10m             
 
 orbs:
   azure-cli: circleci/azure-cli@1.0.0      
 
 workflows:
   version: 2
+
+  cleanup:
+    jobs:
+      - delete_resource_group:
+          filters:
+            branches:
+              only:
+                - /delete_resource_group\/.*/ # match with delete_resource_group/ prefix
 
   performance-tests:
     jobs:

--- a/azure/delete-resource-group-job.sh
+++ b/azure/delete-resource-group-job.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# fail if trying to reference a variable that is not set.
+set -u
+# exit immediately if a command fails
+set -e
+# echo commands
+set -x
+
+BRANCH=${CIRCLE_BRANCH}
+
+# the resource group name will be after the prefix "delete_resource_group/id_"
+# example branch: delete_resource_group/1231123_ch_benchmark_resource_group
+resource_group_name=$(echo "$BRANCH" | sed -e "s@delete_resource_group/[0-9]\+_@@g")
+
+export RESOURCE_GROUP_NAME="$resource_group_name"
+./delete-resource-group.sh
+

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -82,5 +82,5 @@ ssh_execute "${driver_ip}" "/home/pguser/test-automation/hammerdb/send_pubkey.sh
 
 set +e
 # run hammerdb test, this will be run in a detached session.
-ssh_execute "${driver_ip}" "screen -d -m -L /home/pguser/test-automation/hammerdb/run_all.sh ${coordinator_private_ip} ${driver_private_ip} ${branch_name} ${is_tpcc} ${is_ch} ${username} ${hammerdb_version}"
+ssh_execute "${driver_ip}" "screen -d -m -L /home/pguser/test-automation/hammerdb/run_all.sh ${coordinator_private_ip} ${driver_private_ip} ${branch_name} ${is_tpcc} ${is_ch} ${username} ${hammerdb_version} ${cluster_rg}"
 set -e

--- a/hammerdb/delete-resource-group.sh
+++ b/hammerdb/delete-resource-group.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# fail if trying to reference a variable that is not set.
+set -u
+# exit immediately if a command fails
+set -e
+# echo commands
+set -x
+
+cluster_rg=$1
+
+cd /tmp
+
+# add github to known hosts
+echo "github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==" >> ~/.ssh/known_hosts
+
+git clone https://github.com/citusdata/test-automation.git
+
+git config --global user.email "citus-bot@microsoft.com" 
+git config --global user.name "citus bot"
+
+# use the current second as id
+id=$(date +"%s")
+
+cd test-automation
+git checkout -b delete_resource_group/"${id}"_"${cluster_rg}"
+git push origin delete_resource_group/"${id}"_"${cluster_rg}"
+

--- a/hammerdb/run_all.sh
+++ b/hammerdb/run_all.sh
@@ -14,6 +14,7 @@ is_tpcc=$4
 is_ch=$5
 username=$6
 hammerdb_version=$7
+cluster_rg=$8
 
 # store hammerdb version in a file so that we can get it in other scripts
 echo "${hammerdb_version}" > ~/HAMMERDB_VERSION
@@ -37,3 +38,4 @@ done
 
 cp -r "${HOME}"/test-automation/fabfile/hammerdb_confs "${HOME}"/HammerDB-"${hammerdb_version}"/results
 "${HOME}"/test-automation/hammerdb/upload-results.sh "${branch_name}"
+"${HOME}"/test-automation/hammerdb/delete-resource-group.sh "${cluster_rg}"


### PR DESCRIPTION
A job to delete a resource group added. If a branch starts with
`delete_resource_group/` it will delete the resource group by extracting
it from the branch name.

Hammerdb job will push a branch to test automation to trigger this job
so that we don't need to manually delete the resource group after
hammerdb benchmarks are done.

For example, if the resource group name is `citusbot_resource_group_name`,
hammerdb will push the following branch to test automation after
completion: `delete_resource_group/<id>_citusbot_resource_group_name` and
the job will extract the resource group name to delete it.

We can make this deletion optional as well in case we want to ssh to the cluster, but we rarely do. So we can do that optional later as well.

This might create pollution in the repository as we will have many delete_resource_group/ branches. 

One solution is add a nightly job to delete these branches as a cleanup.

Another solution is to remove all delete_resource_group/ branches before pushing to delete_resource/group from the script. Though one downside for this solution is that if there is a concurrent ongoing deletion it will stop that. Though it is not that likely.

I would prefer the first solution as we will need to delete some other branches periodically as well for the hammerdb job on community.

Also it is not a big problem to have many branches in test automation, so we can do it later.
