### PR TITLE
install azure client rpm to have correct certificates

### DIFF
--- a/azure/init.sh
+++ b/azure/init.sh
@@ -10,6 +10,10 @@ set -o pipefail
 # in redhat we need to enable default port for postgres
 firewall-cmd --add-port=5432/tcp
 
+# install azure client rpm to have correct certificates
+curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel7/Packages/r/rhui-azure-rhel7-2.2-97.noarch.rpm
+rpm -U azureclient.rpm
+
 # install pip since we will use it to install dependencies
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
 python get-pip.py


### PR DESCRIPTION
This is not a problem in driver-init.sh because the driver OS is 7.5
whereas other instances are 7.2. The reason for using different versions
in driver and other instances goes back to not using python 3 in fab and
some other stuff.

Note that in order to test this, you will need to update https://github.com/citusdata/test-automation/blob/master/azure/azuredeploy.json#L389 with the branch that has this commit. I already tested it and it seems to fix the problem.

Fixes #172 