### PR TITLE
Always enable debug symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -655,7 +655,7 @@ fab use.enterprise:v7.1.1 setup.enterprise
 fab use.debug_mode use.postgres:10.1 use.citus:v7.1.1 setup.basic_testing
 ```
 
-`use.debug_mode` passes the following flags to postges' configure: `--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"`
+`use.debug_mode` passes the following flags to postges' configure: `--enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"`
 
 `use.asserts` passes `--enable-cassert`, it's a subset of `use.debug_mode`.
 

--- a/fabfile/config.py
+++ b/fabfile/config.py
@@ -15,7 +15,8 @@ RESULTS_DIRECTORY = os.path.join(HOME_DIR, 'results')
 CITUS_INSTALLATION = os.path.join(HOME_DIR, 'citus-installation')
 
 PG_VERSION = '9.6.1'
-PG_CONFIGURE_FLAGS = ['--with-openssl']
+PG_CONFIGURE_FLAGS = ['--with-openssl --enable-debug']
+PG_CFLAGS = ['-ggdb -g3']
 
 settings = {
     IS_SSH_KEYS_USED: True

--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -46,15 +46,13 @@ def tpch():
 
 @task
 def valgrind():
-    'Just like basic_testing, but adds --enable-debug flag and installs valgrind'
+    'Just like basic_testing, but installs valgrind'
     execute(prefix.ensure_pg_latest_exists, default=config.CITUS_INSTALLATION)
 
     # we do this execute dance so valgrind is installed on every node, not just the master
     def install_valgrind():
         sudo('yum install -q -y valgrind')
     execute(install_valgrind)
-
-    config.PG_CONFIGURE_FLAGS.append('--enable-debug')
 
     execute(common_setup, build_citus)
     execute(add_workers)    
@@ -185,6 +183,7 @@ def build_postgres():
         with cd(final_dir):
             pg_latest = config.PG_LATEST
             flags = ' '.join(config.PG_CONFIGURE_FLAGS)
+            flags += ' CFLAGS="%s"' % ' '.join(config.PG_CFLAGS).replace('"', '\\"')
             with hide('stdout'):
                 run('./configure --prefix={} {}'.format(pg_latest, flags))
 

--- a/fabfile/use.py
+++ b/fabfile/use.py
@@ -77,5 +77,10 @@ def asserts(*args):
 
 @task
 def debug_mode(*args):
-    '''ps's configure is passed: '--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"' '''
-    config.PG_CONFIGURE_FLAGS.append('--enable-debug --enable-cassert CFLAGS="-ggdb -Og -g3 -fno-omit-frame-pointer"')
+    '''
+    pg's configure is passed: '--enable-debug --enable-cassert CFLAGS="-ggdb -g3 -Og -fno-omit-frame-pointer"' 
+    Normally this does not contain --enable-cassert, -Og and
+    -fno-omit-frame-pointer. The rest are default.
+    '''
+    config.PG_CONFIGURE_FLAGS.append('--enable-cassert')
+    config.PG_CFLAGS.append('-Og -fno-omit-frame-pointer')


### PR DESCRIPTION
This doesn't make execution slower for GCC compiles according to
Postgres docs:

    --enable-debug

        Compiles all programs and libraries with debugging symbols. This
        means that you can run the programs in a debugger to analyze
        problems. This enlarges the size of the installed executables
        considerably, and on non-GCC compilers it usually also disables
        compiler optimization, causing slowdowns. However, having the
        symbols available is extremely helpful for dealing with any
        problems that might arise. Currently, this option is recommended
        for production installations only if you use GCC. But you should
        always have it on if you are doing development work or running a
        beta version.

The `-ggdb` and `-g3` flags simply tell which type of debug symbols we
want.