### PR TITLE
use centos in our vms

### DIFF
--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -116,8 +116,8 @@
         }
     },
     "variables": {
-        "imagePublisher": "RedHat",
-        "imageOffer": "RHEL",
+        "imagePublisher": "OpenLogic",
+        "imageOffer": "CentOS",
         "imageSku": "7.2",
         "storageAcctName": "[take(concat(parameters('clusterName'), uniqueString(resourceGroup().id)),24)]",
         "networkSecurityGroupName": "networkSecurityGroup1",

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -6,13 +6,13 @@ set -u
 set -e
 # fail in a pipeline if any of the commands fails
 set -o pipefail
+# echo commands
+set -x
 
 # in redhat we need to enable default port for postgres
-firewall-cmd --add-port=5432/tcp
-
-# install azure client rpm to have correct certificates
-curl -o azureclient.rpm https://rhui-1.microsoft.com/pulp/repos/microsoft-azure-rhel7/Packages/r/rhui-azure-rhel7-2.2-97.noarch.rpm
-rpm -U azureclient.rpm
+# We don't exit on this command because if we are on centos, the firewall
+# might not be active, but this also enables switching to redhat easily.
+firewall-cmd --add-port=5432/tcp || true 
 
 # install pip since we will use it to install dependencies
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -147,8 +147,8 @@
         }
     },
     "variables": {
-        "imagePublisher": "RedHat",
-        "imageOffer": "RHEL",
+        "imagePublisher": "OpenLogic",
+        "imageOffer": "CentOS",
         "imageSku": "7.2",
         "driverImageSku" : "7.5",
         "storageAcctName": "[take(concat(parameters('clusterName'), uniqueString(resourceGroup().id)),24)]",

--- a/hammerdb/driver-init.sh
+++ b/hammerdb/driver-init.sh
@@ -8,7 +8,9 @@ set -e
 set -x
 
 # in redhat we need to enable default port for postgres
-firewall-cmd --add-port=5432/tcp
+# We don't exit on this command because if we are on centos, the firewall
+# might not be active, but this also enables switching to redhat easily.
+firewall-cmd --add-port=5432/tcp || true 
 
 # install pip since we will use it to install dependencies
 curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py


### PR DESCRIPTION
We were using redhat in our vms but it turns out to have some problems.
Currently centos seems to be running smoothly. So switching to centos
makes sense, and it doesn't require many changes. We can go back to
redhat or even make it configurable easily.

In another PR the versions will be increased to the latest 7.X.