### PR TITLE
log start time of each query and log checkpoints

### DIFF
--- a/fabfile/hammerdb_confs/master.ini
+++ b/fabfile/hammerdb_confs/master.ini
@@ -19,6 +19,7 @@ postgresql_conf: [
     "effective_io_concurrency = 128",
     "citus.shard_count = 60",
     "track_io_timing = 'off'",
-    "citus.enable_deadlock_prevention = 'off'"
+    "citus.enable_deadlock_prevention = 'off'",
+    "log_checkpoints = 'on'"
     ]
 use_enterprise: off

--- a/hammerdb/ch_benchmark.py
+++ b/hammerdb/ch_benchmark.py
@@ -11,6 +11,7 @@ from os.path import expanduser
 from threading import Thread
 from time import sleep
 import time 
+import datetime
 
 ch_queries = [
     """
@@ -417,12 +418,14 @@ def send_query(query,cur_index):
     global coord_ip
     pg = ['psql', '-P', 'pager=off', '-v', 'ON_ERROR_STOP=1', '-h', coord_ip, '-c', query]
 
+    start_datetime = datetime.datetime.now()
     start_time = int(round(time.time() * 1000))
     return_code = subprocess.call(pg)
     end_time = int(round(time.time() * 1000))
 
     f = open("results/ch_queries_{}.txt".format(file_suffix), "a")
     # we print cur_index + 1 to be human readable (e.g: 1th query will be 1)
+    f.write("{} started at {}\n".format(cur_index+1, start_datetime))
     f.write("{} finished in {} milliseconds\n".format(cur_index+1, end_time - start_time))
     f.close()
 


### PR DESCRIPTION
It is useful to log checkpoints so that we know when they are run and
how they affect the runtimes. In order to understand how they affect the
runtime we should also know when each query started. So that is also
added.
In terms of performance there shouldn't be any difference as there won't
be lots of checkpoint logs.