### PR TITLE
run H part for 1 hour by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -498,7 +498,7 @@ What files are pushed to github:
 Note that running a benchmark with a single config file with a vuuser of 250 and 1000 warehouses could
 take around 2-3 hours. (the whole process)
 
-If you want to run only the tpcc benchmark or the analytical queries, you should change the `is_tpcc` and `is_ch` variables in `create-run.sh`. For example if you want to run only tpcc benchmarks, you should set `is_tpcc` to `true` and `is_ch` to `false` (Alternatively you can see `IS_CH` and `IS_TPCC` environment variables). When you are only running the analytical queries, you can also specify how long you want them to be run by changing the `DEFAULT_CH_RUNTIME_IN_SECS` variable in `build-and-run.sh`. By default it will be run 1800 seconds.
+If you want to run only the tpcc benchmark or the analytical queries, you should change the `is_tpcc` and `is_ch` variables in `create-run.sh`. For example if you want to run only tpcc benchmarks, you should set `is_tpcc` to `true` and `is_ch` to `false` (Alternatively you can see `IS_CH` and `IS_TPCC` environment variables). When you are only running the analytical queries, you can also specify how long you want them to be run by changing the `DEFAULT_CH_RUNTIME_IN_SECS` variable in `build-and-run.sh`. By default it will be run 3600 seconds.
 
 You can change the thread count and initial sleep time for analytical queries from `build-and-run.sh` with `CH_THREAD_COUNT` and `RAMPUP_TIME` variables respectively.
 

--- a/hammerdb/build-and-run.sh
+++ b/hammerdb/build-and-run.sh
@@ -28,7 +28,7 @@ CH_THREAD_COUNT=1
 RAMPUP_TIME=3
 # DEFAULT_CH_RUNTIME_IN_SECS is used when tpcc part is disabled. If tpcc is disabled, this is 
 # how long we will run the analytical queries in second.
-DEFAULT_CH_RUNTIME_IN_SECS=1800
+DEFAULT_CH_RUNTIME_IN_SECS=3600
 
 connection_string=postgres://${username}:${password}@${coordinator_ip_address}:${port}
 # you can set the connection string here if you already have it.


### PR DESCRIPTION
Since we have standardized our runs to 1 hour, running only the H part
for 1 hour will be consistent.