### PR TITLE
retry more times in case of timeout error

### DIFF
--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -15,7 +15,7 @@ ssh_execute() {
    shift;
    command=$@
    n=0
-   until [ $n -ge 4 ]
+   until [ $n -ge 10 ]
    do
       sh ./delete-security-rule.sh
       ssh -o "StrictHostKeyChecking no" -A pguser@${ip} "source ~/.bash_profile;${command}" && break
@@ -27,7 +27,7 @@ ssh_execute() {
       n=$[$n+1]
    done
 
-   if [ $n == 4 ]; then
+   if [ $n == 10 ]; then
       exit 1
    fi
 }

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -21,7 +21,7 @@ ssh_execute() {
    shift;
    command=$*
    n=0
-   until [ $n -ge 4 ]
+   until [ $n -ge 10 ]
    do
       # delete the security before each try
       sh "${topdir}"/azure/delete-security-rule.sh
@@ -29,7 +29,7 @@ ssh_execute() {
       n=$((n+1))
    done
 
-   if [ $n == 4 ]; then
+   if [ $n == 10 ]; then
       exit 1
    fi
 }


### PR DESCRIPTION
We have an extra security rule in azure vms and we delete that rule
before sshing, however sometimes the rule comes back too quickly and we
get a timeout while trying to ssh. Normally we would retry 4 times but
sometimes the issue is persistent for a bit more, so increasing it makes
sense.