### PR TITLE
Add command to add coordinator to the cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,17 @@ fab pg.set_config:max_connections,1000
 fab pg.restart
 ```
 
+If you want to add the coordinator to the cluster, you can run:
+
+```bash
+fab add.coordinator_to_metadata
+```
+
+If you want the coordinator to have shards, you can run:
+
+```bash
+fab add.shards_on_coordinator 
+```
 
 ## <a name="pgbench"></a> Running PgBench Tests
 

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -40,7 +40,7 @@
         },
         "numberOfWorkers": {
             "defaultValue": 3,
-            "minValue": 1,
+            "minValue": 0,
             "maxValue": 21,
             "type": "int",
             "metadata": {

--- a/fabfile/config.py
+++ b/fabfile/config.py
@@ -13,6 +13,7 @@ PG_SOURCE_BALLS = os.path.join(HOME_DIR, 'postgres-source')
 HOME_DIRECTORY = HOME_DIR
 RESULTS_DIRECTORY = os.path.join(HOME_DIR, 'results')
 CITUS_INSTALLATION = os.path.join(HOME_DIR, 'citus-installation')
+PORT = 5432
 
 PG_VERSION = '9.6.1'
 PG_CONFIGURE_FLAGS = ['--with-openssl']

--- a/fabfile/utils.py
+++ b/fabfile/utils.py
@@ -5,6 +5,7 @@ A grab bag of functions used by other modules
 import re
 import os.path
 import os
+import socket
 
 from fabric.api import run, cd
 from fabric.contrib.files import append, exists
@@ -55,3 +56,6 @@ def download_pg():
 
 def pg_url_for_version(version):
     return 'https://ftp.postgresql.org/pub/source/v{0}/postgresql-{0}.tar.bz2'.format(version)
+
+def get_local_ip():
+    return socket.gethostbyname(socket.gethostname())


### PR DESCRIPTION
Fixes #192 

The command to run to add the coordinator to the metadata:

```bash
fab add.coordinator_to_metadata
```

The command to add shards to the coordinator:

```bash
fab add.shards_to_coordinator
```

Tested in a cluster with 0 worker node.