### PR TITLE
Enable repartition joins in tpch and update executor

### DIFF
--- a/fabfile/run.py
+++ b/fabfile/run.py
@@ -199,7 +199,9 @@ def tpch_queries(query_info, connectionURI, pg_version, citus_version, config_fi
 
     for query_code, executor_type in query_info:
         executor_string = "set citus.task_executor_type to '{}'".format(executor_type)
-        run_string = '{} {} -c "{}" -c "\\timing" -f "{}"'.format(psql, connectionURI, executor_string, tpch_path + query_code)
+        enable_repartition_joins = "set citus.enable_repartition_joins to 'on'"
+        run_string = '{} {} -c "{}" -c "{}" -c "\\timing" -f "{}"'.format(psql, connectionURI,
+            enable_repartition_joins, executor_string, tpch_path + query_code)
         out_val = run(run_string)
         results_file.write(out_val)
         results_file.write('\n')

--- a/fabfile/tpch_confs/tpch_default.ini
+++ b/fabfile/tpch_confs/tpch_default.ini
@@ -1,7 +1,7 @@
 [test]
 use_enterprise: on
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
-tpch_tasks_executor_types: [('1.sql', 'real-time'), ('3.sql', 'task-tracker'), ('5.sql', 'task-tracker'), ('6.sql', 'real-time')
-                            ,('7.sql', 'task-tracker'), ('8.sql', 'task-tracker'), ('9.sql', 'task-tracker'), ('10.sql', 'task-tracker')
-                            , ('12.sql', 'real-time'), ('14.sql', 'task-tracker'), ('19.sql', 'task-tracker')]
+tpch_tasks_executor_types: [('1.sql', 'adaptive'), ('3.sql', 'adaptive'), ('5.sql', 'adaptive'), ('6.sql', 'adaptive')
+                            ,('7.sql', 'adaptive'), ('8.sql', 'adaptive'), ('9.sql', 'adaptive'), ('10.sql', 'adaptive')
+                            , ('12.sql', 'adaptive'), ('14.sql', 'adaptive'), ('19.sql', 'adaptive')]
 scale_factor: 10

--- a/jdbc/JDBCReleaseTest.java
+++ b/jdbc/JDBCReleaseTest.java
@@ -34,7 +34,7 @@ public class JDBCReleaseTest {
 	{
 		String query = "SELECT count(*) FROM orders;";
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQuery(query, large_table_shard_count, task_executor_type);
 		
@@ -47,7 +47,7 @@ public class JDBCReleaseTest {
 	{
 		String query = "SELECT count(*) FROM orders, lineitem WHERE	o_orderkey = l_orderkey;";
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQuery(query, large_table_shard_count, task_executor_type);
 		
@@ -61,7 +61,7 @@ public class JDBCReleaseTest {
 	{
 		String query = "SELECT count(*) FROM orders, customer WHERE o_custkey = c_custkey;";
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQuery(query, large_table_shard_count, task_executor_type);
 	}
@@ -70,7 +70,7 @@ public class JDBCReleaseTest {
 	{
 		String query = "SELECT count(*) FROM orders, customer, lineitem WHERE o_custkey = c_custkey AND o_orderkey = l_orderkey;";
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQuery(query, large_table_shard_count, task_executor_type);
 	}
@@ -81,7 +81,7 @@ public class JDBCReleaseTest {
 	{
 		String query = "SELECT	count(*) FROM orders, lineitem WHERE o_orderkey = l_orderkey AND l_suppkey > ?;";
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQueryWithParam(query, large_table_shard_count, task_executor_type, 155);
 		
@@ -94,7 +94,7 @@ public class JDBCReleaseTest {
 		String query = "SELECT supp_nation::text, cust_nation::text, l_year::int, sum(volume)::double precision AS revenue FROM ( SELECT supp_nation, cust_nation, extract(year FROM l_shipdate) AS l_year, l_extendedprice * (1 - l_discount) AS volume FROM supplier, lineitem, orders, customer, ( SELECT n1.n_nationkey AS supp_nation_key, n2.n_nationkey AS cust_nation_key, n1.n_name AS supp_nation, n2.n_name AS cust_nation FROM nation n1, nation n2 WHERE ( (n1.n_name = ? AND n2.n_name = ?) OR (n1.n_name = ? AND n2.n_name = ?) ) ) AS temp WHERE s_suppkey = l_suppkey AND o_orderkey = l_orderkey AND c_custkey = o_custkey AND s_nationkey = supp_nation_key AND c_nationkey = cust_nation_key AND l_shipdate between date '1995-01-01' AND date '1996-12-31' ) AS shipping GROUP BY supp_nation, cust_nation, l_year ORDER BY supp_nation, cust_nation, l_year; ";
 
 		String large_table_shard_count = "2";
-		String task_executor_type = "task-tracker";
+		String task_executor_type = "adaptive";
 		
 		executePreparedQueryWithTwoParam(query, large_table_shard_count, task_executor_type, "RUSSIA", "UNITED STATES");
 		executePreparedQueryWithTwoParam(query, large_table_shard_count, task_executor_type, "GERMANY", "FRANCE");


### PR DESCRIPTION
We should revisit our tests one by one and do necessary changes because some of them are outdated and some tests might not have any value. But it is a bigger thing 