### PR TITLE
Fix task names in use

### DIFF
--- a/fabfile/use.py
+++ b/fabfile/use.py
@@ -12,6 +12,8 @@ import setup
 import config
 import utils
 
+__all__ = ['citus', 'enterprise', 'postgres', 'hammerdb', 'asserts', 'debug_mode', 'valgrind']
+
 @task
 def citus(*args):
     'Choose a citus version. For example: fab use.citus:v6.0.1 setup.basic_testing (defaults to master)'


### PR DESCRIPTION
It seems like since we didn't have task names in `use.py` when importing `setup.py`, the task names of `setup` had the prefix of `use`. As in `setup.hammerdb` would be `use.setup.hammerdb`, which is not what we want. To prevent that, we define the `__all__` in `use.py`.