### PR TITLE
Use upstream hammerdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ If you want to run only the tpcc benchmark or the analytical queries, you should
 
 You can change the thread count and initial sleep time for analytical queries from `build-and-run.sh` with `CH_THREAD_COUNT` and `RAMPUP_TIME` variables respectively.
 
-If you want to run hammerdb4.0 change `hammerdb_branch` to `hammerdb40` in `create-run.sh`.
+If you want to run hammerdb4.0 change `hammerdb_version` to `4.0` in `create-run.sh`.
 
 By default a random region will be used, if you want you can specify the region with `AZURE_REGION` environment variable prior to running `create-run.sh` such as `export AZURE_REGION=westus2`.
 

--- a/hammerdb/build-and-run.sh
+++ b/hammerdb/build-and-run.sh
@@ -56,7 +56,7 @@ psql -v "ON_ERROR_STOP=1" "${connection_string}" -f ch-benchmark-distribute.sql
 # psql -h ${coordinator_ip_address} -f tpcc-distribute.sql
 
 # distribute functions in cluster 
-psql -v "ON_ERROR_STOP=1" "${connection_string}" -f tpcc-distribute-funcs.sql
+# psql -v "ON_ERROR_STOP=1" "${connection_string}" -f tpcc-distribute-funcs.sql
 
 # do vacuum to get more accurate results.
 psql -v "ON_ERROR_STOP=1" "${connection_string}" -f vacuum-ch.sql

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -10,8 +10,7 @@ set -x
 is_tpcc=${IS_TPCC:=true} # set to true if you want tpcc to be run, otherwise set to false
 is_ch=${IS_CH:=true} # set to true if you want ch benchmark to be run, otherwise set to false
 username=pguser # username of the database
-hammerdb_version=3.3
-hammerdb_branch=hammerdb33 # for hammerdb 3.3 use hammerdb33, for hammerdb 4.0 use hammerdb40
+hammerdb_version=4.0 # use 3.3 for hammerdb3, 4.0 for hammerdb4
 
 # ssh_execute is used to run a command multiple times on ssh, this is because we sometimes get timeouts 
 # while trying to ssh, and it shouldn't make the script fail. If a command actually fails, it will always
@@ -83,7 +82,7 @@ ssh_execute "${driver_ip}" "/home/pguser/test-automation/hammerdb/send_pubkey.sh
 
 set +e
 # run hammerdb test, this will be run in a detached session.
-ssh_execute "${driver_ip}" "screen -d -m -L /home/pguser/test-automation/hammerdb/run_all.sh ${coordinator_private_ip} ${driver_private_ip} ${branch_name} ${is_tpcc} ${is_ch} ${username} ${hammerdb_version} ${hammerdb_branch} ${cluster_rg}"
+ssh_execute "${driver_ip}" "screen -d -m -L /home/pguser/test-automation/hammerdb/run_all.sh ${coordinator_private_ip} ${driver_private_ip} ${branch_name} ${is_tpcc} ${is_ch} ${username} ${hammerdb_version} ${cluster_rg}"
 set -e
 
 echo "Successfully started the benchmark(There can still be runtime errors)!"

--- a/hammerdb/driver-init.sh
+++ b/hammerdb/driver-init.sh
@@ -19,7 +19,7 @@ python get-pip.py
 rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 # install git to clone the repository
 # install screen so that we can run commands in a detached session
-yum install -y git screen tmux htop
+yum install -y git screen tmux htop patch
 
 # this is the username in our instances
 TARGET_USER=pguser

--- a/hammerdb/run_all.sh
+++ b/hammerdb/run_all.sh
@@ -32,7 +32,7 @@ do
   # get the file name from absolute path 
   config_file=$(basename "$config_file")
 
-  ssh -o "StrictHostKeyChecking no" -A "${coordinator_private_ip}" "source ~/.bash_profile;fab setup.hammerdb:${config_file},driver_ip=${driver_private_ip}"
+  ssh -o "StrictHostKeyChecking no" -A "${coordinator_private_ip}" "source ~/.bash_profile;fab --show=debug setup.hammerdb:${config_file},driver_ip=${driver_private_ip}"
   "${HOME}"/test-automation/hammerdb/build-and-run.sh "${coordinator_private_ip}" "${config_file}" "${is_tpcc}" "${is_ch}" "${username}"
 done
 

--- a/hammerdb/run_all.sh
+++ b/hammerdb/run_all.sh
@@ -14,8 +14,7 @@ is_tpcc=$4
 is_ch=$5
 username=$6
 hammerdb_version=$7
-hammerdb_branch=$8
-cluster_rg=$9
+cluster_rg=$8
 
 # store hammerdb version in a file so that we can get it in other scripts
 echo "${hammerdb_version}" > ~/HAMMERDB_VERSION
@@ -25,7 +24,7 @@ echo "${hammerdb_version}" > ~/HAMMERDB_VERSION
 echo "\pset pager off" >> ~/.psqlrc
 
 # do setup of cluster
-"${HOME}"/test-automation/hammerdb/setup.sh "${coordinator_private_ip}" "${username}" "${hammerdb_branch}"
+"${HOME}"/test-automation/hammerdb/setup.sh "${coordinator_private_ip}" "${username}"
 
 # for each hammerdb config, run the tests and store the results
 for config_file in "${HOME}/test-automation/fabfile/hammerdb_confs"/*

--- a/hammerdb/setup.sh
+++ b/hammerdb/setup.sh
@@ -16,7 +16,7 @@ hammerdb_version=$(cat ~/HAMMERDB_VERSION)
 hammerdb_dir="${HOME}"/HammerDB-"${hammerdb_version}"
 
 cd "${HOME}"
-git clone https://github.com/citusdata/ch-benchmark.git
+git clone -b test-automation https://github.com/citusdata/ch-benchmark.git
 cd ch-benchmark
 ./generate-hammerdb.sh "$hammerdb_version"
 mv HammerDB-"${hammerdb_version}" ~/

--- a/hammerdb/setup.sh
+++ b/hammerdb/setup.sh
@@ -9,7 +9,6 @@ set -x
 
 coordinator_ip_address=$1
 username=$2
-hammerdb_branch=$3
 
 driverdir="${0%/*}"
 
@@ -17,19 +16,10 @@ hammerdb_version=$(cat ~/HAMMERDB_VERSION)
 hammerdb_dir="${HOME}"/HammerDB-"${hammerdb_version}"
 
 cd "${HOME}"
-
-wget "https://github.com/TPC-Council/HammerDB/releases/download/v${hammerdb_version}/HammerDB-${hammerdb_version}-Linux.tar.gz"
-tar -zxvf HammerDB-"${hammerdb_version}"-Linux.tar.gz
-
-# here we use our fork, because it distributed tables at the beginning, which speeds up the process
-# since we can create indexes in parallel etc.
-git clone --branch "${hammerdb_branch}" https://github.com/citusdata/HammerDB.git
-mv HammerDB/src/postgresql/pgoltp.tcl "${hammerdb_dir}"/src/postgresql/pgoltp.tcl
-mv HammerDB/config/postgresql.xml "${hammerdb_dir}"/config/postgresql.xml
-
-# cd ${hammerdb_dir}/src/postgresql
-# comment out create database and user as citus cannot do that
-# sed -i 's/CreateUserDatabase $lda $db $superuser $user $password/#CreateUserDatabase $lda $db $superuser $user $password/g' pgoltp.tcl
+git clone https://github.com/citusdata/ch-benchmark.git
+cd ch-benchmark
+./generate-hammerdb.sh "$hammerdb_version"
+mv HammerDB-"${hammerdb_version}" ~/
 
 # postgres is necessary for hammerdb, so install that
 sudo yum -y install https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm

--- a/hammerdb/upload-results.sh
+++ b/hammerdb/upload-results.sh
@@ -7,7 +7,8 @@ set -e
 # echo commands
 set -x
 
-hammerdb_dir="${HOME}"/HammerDB-3.3
+hammerdb_version=$(cat ~/HAMMERDB_VERSION)
+hammerdb_dir="${HOME}"/HammerDB-"${hammerdb_version}"
 rg_name=$1
 
 cd "${hammerdb_dir}"


### PR DESCRIPTION
When we use a custom hammerdb branch with citus related changes, the
branch easily get outdated. It makes more sense to apply only the
relevant patch to the upstream.