### PR TITLE
Expose multiple ports on ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The data will be stored on the attached disk, size of which can be configured in
 
 If you dont specify the region, a random region among `eastus`, `west us 2` and `south central us` will be chosen. This is to use resources uniformly from different regions.
 
+**Port 3456 is used for ssh, you can connect to any node via Port 3456, if you don't use this node, you will hit the security rules.**
+
 ## <a name="azure-setup-steps"></a> Setup Steps For Each Test
 
 You will need to follow these steps to create a cluster and connect to it, on your local machine:
@@ -98,14 +100,6 @@ less azuredeploy.parameters.json
 
 # connect to the coordinator
 ./connect.sh
-
-# ALTERNATIVATELY instead of ./connect.sh you can do the following
-
-# Delete security rule 103 to be able to connect
-./delete-security-rule.sh
-
-# When your cluster is ready, it will prompt you with the connection string, connect to coordinator node
-ssh -A pguser@<public ip of coordinator>
 ```
 
 ## <a name="azure-delete-cluster"></a> Steps to delete a cluster
@@ -140,9 +134,9 @@ The first virtual machine with index 0 is treated as a coordinator. When all the
 
 The initialization script also finds the private ip addresses of workers and puts them to the coordinator. The way this is done is with a storage account resource. This storage account resource is created within the template itself and all the vms upload their private ip addresses to the storage. After all are uploaded the coordinator downloads all the private ip addresses from the storage account and puts it to `worker-instances` file, which is then used when creating a citus cluster.
 
-We have a special security group which blocks ssh traffic. The rule's priority is 103 and 100, 101, 102 are also taken by this security group. The workaround to connect to the coordinator is to remove the rule 103, and connect right after it. The rule comes back in 2-3 mins, so you should be fast here. There is a script called `delete-security-rule.sh`, which deletes that rule for you.
+We have a special security group which blocks ssh traffic. The rule's priority is 103 and 100, 101, 102 are also taken by this security group.
 
-You can use `connect.sh` which will delete the security rule and connect to the coordinator for you.
+You can use `connect.sh` which will connect to the coordinator for you on a custom ssh port (at the time of writing 3456).
 
 Before starting the process you should set the environment variable `RESOURCE_GROUP_NAME`, which is used in all scripts.
 
@@ -170,13 +164,6 @@ then you should run:
 
 ```bash
 ./connect.sh
-```
-
-or
-
-```bash
-./delete-security-rule.sh
-ssh -A pguser@<public ip of coordinator>
 ```
 
 After you are done with testing, you can delete the resource group with:

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -401,7 +401,7 @@
                 "settings": {
                     "commandToExecute": "[concat('sh init.sh ', copyIndex(), ' ', variables('numberOfInstances'), ' ', variables('storageAcctName'), ' ', listKeys(variables('storageAcctName'),'2017-10-01').keys[0].value, ' ', parameters('branchName'))]",
                     "fileUris": [
-                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/azure/init.sh"
+                        "https://raw.githubusercontent.com/citusdata/test-automation/master/azure/init.sh"
                     ]
                 }
             },

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -386,7 +386,7 @@
                 "settings": {
                     "commandToExecute": "[concat('sh init.sh ', copyIndex(), ' ', variables('numberOfInstances'), ' ', variables('storageAcctName'), ' ', listKeys(variables('storageAcctName'),'2017-10-01').keys[0].value, ' ', parameters('branchName'))]",
                     "fileUris": [
-                        "https://raw.githubusercontent.com/citusdata/test-automation/master/azure/init.sh"
+                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/azure/init.sh"
                     ]
                 }
             },

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -128,7 +128,8 @@
         "publicIPAddressType": "Static",
         "publicIPAddressName": "citusPublicIP",
         "numberOfInstances":"[add(parameters('numberOfWorkers'), 1)]",
-        "ppgName": "citusPPG"
+        "ppgName": "citusPPG",
+        "customSshPort": 3456
     },
     "resources": [
         {
@@ -213,6 +214,20 @@
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 101,
+                            "direction": "Inbound"
+                        }
+                    },
+                        {
+                        "name": "customSshPort",
+                        "properties": {
+                            "description": "custom ssh port",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "[variables('customSshPort')]",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 102,
                             "direction": "Inbound"
                         }
                     }
@@ -398,11 +413,15 @@
     ],
     "outputs": {
         "ssh": {
-            "value": "[concat('ssh -A ', parameters('adminUsername'),'@',reference(resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), '0'))).IpAddress)]",
+            "value": "[concat('ssh -A -p ', variables('customSshPort'), ' ', parameters('adminUsername'),'@',reference(resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), '0'))).IpAddress)]",
             "type": "string"
         },
         "publicIP": {
             "value": "[reference(resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), '0'))).IpAddress]",
+            "type": "string"
+        },
+        "customSshPort": {
+            "value": "[variables('customSshPort')]",
             "type": "string"
         }
     }

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -422,7 +422,7 @@
         },
         "customSshPort": {
             "value": "[variables('customSshPort')]",
-            "type": "string"
+            "type": "int"
         }
     }
 }

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -220,7 +220,7 @@
                         {
                         "name": "customSshPort",
                         "properties": {
-                            "description": "custom ssh port",
+                            "description": "allow accessing to custom ssh port from all ip's",
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
                             "destinationPortRange": "[variables('customSshPort')]",

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -17,8 +17,7 @@ ssh_execute() {
    n=0
    until [ $n -ge 10 ]
    do
-      sh ./delete-security-rule.sh
-      ssh -o "StrictHostKeyChecking no" -A pguser@${ip} "source ~/.bash_profile;${command}" && break
+      ssh -o "StrictHostKeyChecking no" -A -p 3456 pguser@${ip} "source ~/.bash_profile;${command}" && break
       rc=$? # get return code
       if [ $rc -ne 255 ] ; then
          # if the error code is not 255 we didn't get a connection error.
@@ -63,8 +62,6 @@ public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 echo ${public_ip}
 ssh-keyscan -H ${public_ip} >> ~/.ssh/known_hosts
 chmod 600 ~/.ssh/known_hosts
-
-sh ./delete-security-rule.sh
 
 echo "adding public ip to known hosts in remote"
 ssh_execute ${public_ip} "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -8,8 +8,7 @@ set -e
 set -x
 
 # ssh_execute tries to send the given command over the given connection multiple times.
-# Before sending the command it deletes the security rule on azure. Sometimes the rule
-# comes back too quick, so we get a timeout, that is why we try multiple times.
+# It uses the custom ssh port 3456.
 ssh_execute() {
    ip=$1
    shift;

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -16,7 +16,7 @@ ssh_execute() {
    n=0
    until [ $n -ge 10 ]
    do
-      ssh -o "StrictHostKeyChecking no" -A -p 3456 pguser@${ip} "source ~/.bash_profile;${command}" && break
+      ssh -o "StrictHostKeyChecking no" -A -p "${ssh_port}" pguser@${ip} "source ~/.bash_profile;${command}" && break
       rc=$? # get return code
       if [ $rc -ne 255 ] ; then
          # if the error code is not 255 we didn't get a connection error.
@@ -54,6 +54,10 @@ if [ "$rg" == "citusbot_valgrind_test_resource_group" ]; then
     # will immediately be closed just after the fabric command is run
     trap - EXIT
 fi
+
+ssh_port=$(az group deployment show -g "${RESOURCE_GROUP_NAME}" -n azuredeploy --query properties.outputs.customSshPort.value)
+# remove the quotes 
+ssh_port=$(echo "${ssh_port}" | cut -d "\"" -f 2)
 
 public_ip=$(az group deployment show -g ${rg} -n azuredeploy --query properties.outputs.publicIP.value)
 # remove the quotes 

--- a/azure/connect.sh
+++ b/azure/connect.sh
@@ -20,4 +20,5 @@ ssh_port=$(az group deployment show -g ${RESOURCE_GROUP_NAME} -n azuredeploy --q
 # remove the quotes 
 public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 ssh_port=$(echo ${ssh_port} | cut -d "\"" -f 2)
+
 ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} -p ${ssh_port}

--- a/azure/connect.sh
+++ b/azure/connect.sh
@@ -15,8 +15,9 @@ azuredir="${0%/*}"
 cd ${azuredir}
 
 public_ip=$(az group deployment show -g ${RESOURCE_GROUP_NAME} -n azuredeploy --query properties.outputs.publicIP.value)
+ssh_port=$(az group deployment show -g ${RESOURCE_GROUP_NAME} -n azuredeploy --query properties.outputs.customSshPort.value)
+
 # remove the quotes 
 public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
-sh ./delete-security-rule.sh
-
-ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip}
+ssh_port=$(echo ${ssh_port} | cut -d "\"" -f 2)
+ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} -p ${ssh_port}

--- a/azure/create-cluster.sh
+++ b/azure/create-cluster.sh
@@ -62,5 +62,4 @@ connection_string=$(echo ${connection_string} | cut -d "\"" -f 2)
 
 echo "run './connect.sh' to connect to the coordinator, or ALTERNATIVELY:"
 
-echo "run './delete-security-rule.sh' to temporarily disable security rule, and connect with:"
 echo ${connection_string}

--- a/azure/create-cluster.sh
+++ b/azure/create-cluster.sh
@@ -60,6 +60,6 @@ connection_string=$(az group deployment show -g ${rg} -n azuredeploy --query pro
 # remove the quotes 
 connection_string=$(echo ${connection_string} | cut -d "\"" -f 2)
 
-echo "run './connect.sh' to connect to the coordinator, or ALTERNATIVELY:"
+echo "run './connect.sh' to connect to the coordinator, or ALTERNATIVELY RUN THE FOLLOWING:"
 
 echo ${connection_string}

--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -24,10 +24,8 @@ echo ${public_ip}
 ssh-keyscan -H ${public_ip} >> ~/.ssh/known_hosts
 chmod 600 ~/.ssh/known_hosts
 
-sh ./delete-security-rule.sh
-
 echo "adding public ip to known hosts in remote"
-ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"
+ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} -p 3456 "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"
 echo "running tests in remote"
 
 # ssh with non-interactive mode does not source bash profile, so we will need to do it ourselves here.

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -11,6 +11,8 @@ set -x
 # We don't exit on this command because if we are on centos, the firewall
 # might not be active, but this also enables switching to redhat easily.
 firewall-cmd --add-port=5432/tcp || true 
+firewall-cmd --add-port=3456/tcp || true 
+
 
 # fail in a pipeline if any of the commands fails
 set -o pipefail

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -43,6 +43,17 @@ rsync -aXS /tmp/home_copy/. /home/${TARGET_USER}/.
 # We do not want the password prompt, because we want to run tests without any user input
 echo '${TARGET_USER}     ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
+# we will use port 3456 to not hit security rule 103
+echo 'Port 3456' >> /etc/ssh/sshd_config
+echo 'Port 22' >> /etc/ssh/sshd_config
+
+# necessary for semanage, VMs have secure linux
+yum install -y policycoreutils-python
+# we need to enable the new port from semanage
+semanage port -a -t ssh_port_t -p tcp 3456
+
+# restart ssh service to be able to use the new port
+systemctl restart sshd
 
 BRANCH=$5
 

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -161,7 +161,8 @@
         "publicIPAddressName": "citusPublicIP",
         "numberOfInstances":"[add(parameters('numberOfWorkers'), 2)]",
         "driverNodeIndex" : "[add(parameters('numberOfWorkers'), 1)]",
-        "ppgName": "citusPPG"
+        "ppgName": "citusPPG",
+        "customSshPort": 3456
     },
     "resources": [
         {
@@ -246,6 +247,20 @@
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
                             "priority": 101,
+                            "direction": "Inbound"
+                        }
+                    },
+                    {
+                        "name": "customSshPort",
+                        "properties": {
+                            "description": "custom ssh port",
+                            "protocol": "Tcp",
+                            "sourcePortRange": "*",
+                            "destinationPortRange": "[variables('customSshPort')]",
+                            "sourceAddressPrefix": "*",
+                            "destinationAddressPrefix": "*",
+                            "access": "Allow",
+                            "priority": 102,
                             "direction": "Inbound"
                         }
                     }
@@ -424,8 +439,8 @@
                     "commandToExecute": "[concat('sh entry.sh ', copyIndex(), ' ', variables('numberOfInstances'), ' ', variables('storageAcctName'), ' ', listKeys(variables('storageAcctName'),'2017-10-01').keys[0].value, ' ', parameters('branchName'), ' ', parameters('git_username'), ' ', parameters('git_token'))]",
                     "fileUris": [
                         "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/entry.sh",
-                        "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/driver-init.sh",
-                        "https://raw.githubusercontent.com/citusdata/test-automation/master/azure/init.sh",
+                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/hammerdb/driver-init.sh",
+                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/azure/init.sh",
                         "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/cache_git_creds.sh"
                     ]
                 }
@@ -438,7 +453,7 @@
     ],
     "outputs": {
         "ssh": {
-            "value": "[concat('ssh -A ', parameters('adminUsername'),'@',reference(resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), '0'))).IpAddress)]",
+            "value": "[concat('ssh -A -p ', variables('customSshPort'), ' ', parameters('adminUsername'),'@',reference(resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), '0'))).IpAddress)]",
             "type": "string"
         },
         "publicIP": {
@@ -456,6 +471,10 @@
         "driverPrivateIP": {
             "value": "[reference(resourceId('Microsoft.Network/networkInterfaces', concat(parameters('clusterName'),'nic', variables('driverNodeIndex')))).ipConfigurations[0].properties.privateIPAddress]",
             "type": "string" 
+        },
+        "customSshPort": {
+            "value": "[variables('customSshPort')]",
+            "type": "int"
         }
     }
 }

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -253,7 +253,7 @@
                     {
                         "name": "customSshPort",
                         "properties": {
-                            "description": "custom ssh port",
+                            "description": "allow accessing to custom ssh port from all ip's",
                             "protocol": "Tcp",
                             "sourcePortRange": "*",
                             "destinationPortRange": "[variables('customSshPort')]",

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -439,8 +439,8 @@
                     "commandToExecute": "[concat('sh entry.sh ', copyIndex(), ' ', variables('numberOfInstances'), ' ', variables('storageAcctName'), ' ', listKeys(variables('storageAcctName'),'2017-10-01').keys[0].value, ' ', parameters('branchName'), ' ', parameters('git_username'), ' ', parameters('git_token'))]",
                     "fileUris": [
                         "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/entry.sh",
-                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/hammerdb/driver-init.sh",
-                        "https://raw.githubusercontent.com/citusdata/test-automation/multiple_ports_on_ssh/azure/init.sh",
+                        "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/driver-init.sh",
+                        "https://raw.githubusercontent.com/citusdata/test-automation/master/azure/init.sh",
                         "https://raw.githubusercontent.com/citusdata/test-automation/master/hammerdb/cache_git_creds.sh"
                     ]
                 }

--- a/hammerdb/connect-driver.sh
+++ b/hammerdb/connect-driver.sh
@@ -16,9 +16,9 @@ cd "${dir}"
 
 # get the public ip of driver from the cluster outputs.
 public_ip=$(az group deployment show -g "${RESOURCE_GROUP_NAME}" -n azuredeploy --query properties.outputs.driverPublicIP.value)
+ssh_port=$(az group deployment show -g "${RESOURCE_GROUP_NAME}" -n azuredeploy --query properties.outputs.customSshPort.value)
 # remove the quotes 
 public_ip=$(echo "${public_ip}" | cut -d "\"" -f 2)
+ssh_port=$(echo "${ssh_port}" | cut -d "\"" -f 2)
 
-# delete the security rule and connect to the driver node.
-sh ../azure/delete-security-rule.sh
-ssh -o "StrictHostKeyChecking no" -A pguser@"${public_ip}"
+ssh -o "StrictHostKeyChecking no" -A pguser@"${public_ip}" -p "${ssh_port}"

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -23,9 +23,7 @@ ssh_execute() {
    n=0
    until [ $n -ge 10 ]
    do
-      # delete the security before each try
-      sh "${topdir}"/azure/delete-security-rule.sh
-      ssh -o "StrictHostKeyChecking no" -A pguser@"${ip}" "source ~/.bash_profile;${command}" && break
+      ssh -o "StrictHostKeyChecking no" -A -p 3456 pguser@"${ip}" "source ~/.bash_profile;${command}" && break
       n=$((n+1))
    done
 

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -23,7 +23,7 @@ ssh_execute() {
    n=0
    until [ $n -ge 10 ]
    do
-      ssh -o "StrictHostKeyChecking no" -A -p 3456 pguser@"${ip}" "source ~/.bash_profile;${command}" && break
+      ssh -o "StrictHostKeyChecking no" -A -p "$ssh_port" pguser@"${ip}" "source ~/.bash_profile;${command}" && break
       n=$((n+1))
    done
 
@@ -47,6 +47,9 @@ cd "${topdir}"/hammerdb
 # create the cluster with driver node
 ./create.sh
 
+ssh_port=$(az group deployment show -g "${RESOURCE_GROUP_NAME}" -n azuredeploy --query properties.outputs.customSshPort.value)
+# remove the quotes 
+ssh_port=$(echo "${ssh_port}" | cut -d "\"" -f 2)
 
 cluster_ip=$(az group deployment show -g "${cluster_rg}" -n azuredeploy --query properties.outputs.publicIP.value)
 # remove the quotes 

--- a/hammerdb/driver-init.sh
+++ b/hammerdb/driver-init.sh
@@ -11,6 +11,7 @@ set -x
 # We don't exit on this command because if we are on centos, the firewall
 # might not be active, but this also enables switching to redhat easily.
 firewall-cmd --add-port=5432/tcp || true 
+firewall-cmd --add-port=3456/tcp || true 
 
 # install pip since we will use it to install dependencies
 curl https://bootstrap.pypa.io/2.7/get-pip.py -o get-pip.py

--- a/hammerdb/driver-init.sh
+++ b/hammerdb/driver-init.sh
@@ -40,6 +40,18 @@ rsync -aXS /tmp/home_copy/. /home/"${TARGET_USER}"/.
 # We do not want the password prompt, because we want to run tests without any user input
 echo '${TARGET_USER}     ALL=(ALL) NOPASSWD:ALL' >>/etc/sudoers
 
+# we will use port 3456 to not hit security rule 103
+echo 'Port 3456' >> /etc/ssh/sshd_config
+echo 'Port 22' >> /etc/ssh/sshd_config
+
+# necessary for semanage, VMs have secure linux
+yum install -y policycoreutils-python
+# we need to enable the new port from semanage
+semanage port -a -t ssh_port_t -p tcp 3456
+
+# restart ssh service to be able to use the new port
+systemctl restart sshd
+
 BRANCH=$1
 
 echo "${BRANCH}" > /tmp/branch_name


### PR DESCRIPTION
Expose multiple ports on ssh so that we don't hit security group rules when trying to connect via the default port, 22.

The custom port we now use for ssh is 3456.

Alternatively I have tried to use a loadbalancer to have port forwarding but it seems that in that case we again hit rule 103 because only internal requests from loadbalancer to vms are allowed and public requests are not.

Fixes #211.