### PR TITLE
Not use ssh-keyscan in local as we already don't check key

### DIFF
--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -63,7 +63,6 @@ public_ip=$(az group deployment show -g ${rg} -n azuredeploy --query properties.
 # remove the quotes 
 public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 echo ${public_ip}
-ssh-keyscan -H ${public_ip} >> ~/.ssh/known_hosts
 chmod 600 ~/.ssh/known_hosts
 
 echo "adding public ip to known hosts in remote"

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -63,7 +63,6 @@ public_ip=$(az group deployment show -g ${rg} -n azuredeploy --query properties.
 # remove the quotes 
 public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 echo ${public_ip}
-chmod 600 ~/.ssh/known_hosts
 
 echo "adding public ip to known hosts in remote"
 ssh_execute ${public_ip} "ssh-keyscan -H ${public_ip} >> /home/pguser/.ssh/known_hosts"

--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -21,7 +21,6 @@ public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 
 echo ${public_ip}
 
-ssh-keyscan -H ${public_ip} >> ~/.ssh/known_hosts
 chmod 600 ~/.ssh/known_hosts
 
 ./add-local-ip.sh

--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -21,8 +21,6 @@ public_ip=$(echo ${public_ip} | cut -d "\"" -f 2)
 
 echo ${public_ip}
 
-chmod 600 ~/.ssh/known_hosts
-
 ./add-local-ip.sh
 
 echo "adding public ip to known hosts in remote"

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -72,9 +72,6 @@ driver_private_ip=$(az group deployment show -g "${cluster_rg}" -n azuredeploy -
 driver_private_ip=$(echo "${driver_private_ip}" | cut -d "\"" -f 2)
 echo "${driver_private_ip}"
 
-# just to be sure, the permission of known_hosts should be 600, otherwise it is ignored.
-chmod 600 ~/.ssh/known_hosts
-
 # add the public key of coordinator to the driver node so that driver can connect to the coordinator 
 # without getting permission error.
 ssh_execute "${driver_ip}" "/home/pguser/test-automation/hammerdb/send_pubkey.sh ${coordinator_private_ip}" 

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -72,9 +72,6 @@ driver_private_ip=$(az group deployment show -g "${cluster_rg}" -n azuredeploy -
 driver_private_ip=$(echo "${driver_private_ip}" | cut -d "\"" -f 2)
 echo "${driver_private_ip}"
 
-# add the cluster and driver ip to our known host so that they don't prompt any verification.
-ssh-keyscan -H "${cluster_ip}" >> ~/.ssh/known_hosts
-ssh-keyscan -H "${driver_ip}" >> ~/.ssh/known_hosts
 # just to be sure, the permission of known_hosts should be 600, otherwise it is ignored.
 chmod 600 ~/.ssh/known_hosts
 


### PR DESCRIPTION
We were using ssh-keyscan but it is no longer needed as we already pass
"StrictHostKeyChecking no" option. This would sometimes fail silently
hence causing confusing for developers.