### PR TITLE
Use custom port when finalizing valgrind testing

### DIFF
--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -31,6 +31,6 @@ echo "running tests in remote"
 # ssh with non-interactive mode does not source bash profile, so we will need to do it ourselves here.
 # put an empty success file for valgrind tests under results dir if there are error logs
 # push the files under results dir
-ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} \
+ssh -o "StrictHostKeyChecking no" -A pguser@${public_ip} -p 3456 \
 "source ~/.bash_profile;" \
 "sh /home/pguser/test-automation/azure/push-results.sh ${RESOURCE_GROUP_NAME}";


### PR DESCRIPTION
Related https://github.com/citusdata/test-automation/pull/212
That's why this week's valgrind test failed https://app.circleci.com/pipelines/github/citusdata/test-automation/1277/workflows/884b4a59-de68-40aa-8b38-250dd9d0fbe4/jobs/620