### PR TITLE
Not expect enterprise configuration if pgbench on cloud

### DIFF
--- a/fabfile/run.py
+++ b/fabfile/run.py
@@ -49,9 +49,9 @@ def pgbench_tests(config_file='pgbench_default.ini', connectionURI=''):
     path = os.path.join(config.RESULTS_DIRECTORY, 'pgbench_results_{}_{}.csv'.format(current_time_mark, config_file))
     results_file = open(path, 'w')
 
-    use_enterprise = config_parser.get('DEFAULT', 'use_enterprise')
-
     if connectionURI == '':
+        use_enterprise = config_parser.get('DEFAULT', 'use_enterprise')
+
         results_file.write("Test, PG Version, Citus Version, Shard Count, Replication Factor, Latency Average, "
                            "TPS Including Connections, TPS Excluding Connections\n")
 


### PR DESCRIPTION
We were expecting `use_enterprise` parameter even if connection string is given, which doesn't make sense because if connection string is given, the cluster is already there.

Also using `DEFAULT` will result in errors but that is a separate issue.