### PR TITLE
Increase max wal size

### DIFF
--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -3,6 +3,7 @@ postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_custom.ini
+++ b/fabfile/pgbench_confs/pgbench_custom.ini
@@ -2,7 +2,7 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '1GB'",
+                 "max_wal_size = '50GB'",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -3,6 +3,7 @@ postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -2,7 +2,7 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '1GB'",
+                 "max_wal_size = '50GB'",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -3,6 +3,7 @@ postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
                  "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -2,7 +2,7 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '1GB'",
+                 "max_wal_size = '50GB'",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/pgbench_issue_1799.ini
+++ b/fabfile/pgbench_confs/pgbench_issue_1799.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000"

--- a/fabfile/pgbench_confs/scale_test.ini
+++ b/fabfile/pgbench_confs/scale_test.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/scale_test_100_columns.ini
+++ b/fabfile/pgbench_confs/scale_test_100_columns.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+ 				 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/scale_test_foreign.ini
+++ b/fabfile/pgbench_confs/scale_test_foreign.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/scale_test_no_index.ini
+++ b/fabfile/pgbench_confs/scale_test_no_index.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/scale_test_prepared.ini
+++ b/fabfile/pgbench_confs/scale_test_prepared.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",

--- a/fabfile/pgbench_confs/scale_test_reference.ini
+++ b/fabfile/pgbench_confs/scale_test_reference.ini
@@ -2,7 +2,8 @@
 postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
 shard_counts_replication_factors: [(32, 1)]
 postgresql_conf: [
-                 "max_wal_size = '5GB'",
+                 "max_wal_size = '50GB'",
+                 "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",


### PR DESCRIPTION
With postgres 14, the `checkpoint_completion_target` is 0.9 by default and it is 0.5 with previous versions. It makes sense to use the same value for different postgres versions in our tests.

Also `max_wal_size = 1GB` is quite small for our tests and we increase it to 50GB to prevent checkpoints during tests.