### PR TITLE
Fix valgrind tests in CI due to offboarded user

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,3 +173,10 @@ workflows:
                 - master
     jobs:
       - finalize-valgrind-test
+
+  onpush-valgrind:
+    jobs:
+      - valgrind-test
+  # onpush-finalize-valgrind:
+  #   jobs:
+  #     - finalize-valgrind-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
-            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -31,7 +30,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
-            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -51,7 +49,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
-            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -87,7 +84,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
-            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -108,7 +104,6 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
-            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,9 @@ jobs:
       - azure-cli/install
       - azure-cli/login-with-service-principal
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
       - run:
           command: |
             cd ./azure
@@ -24,13 +27,16 @@ jobs:
       - azure-cli/install
       - azure-cli/login-with-service-principal
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
       - run:
           command: |
             cd ./azure
             ./add-sshkey.sh
             ./citus-bot.sh citusbot_scale_test_resource_group
           name: install dependencies and run scale tests
-          no_output_timeout: 10m  
+          no_output_timeout: 10m
   
   tpch:
     docker:
@@ -40,6 +46,9 @@ jobs:
       - azure-cli/install
       - azure-cli/login-with-service-principal
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
       - run:
           command: |
             cd ./azure
@@ -74,7 +83,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "06:b9:7d:db:59:54:db:6d:76:7b:f5:28:20:fe:d2:7d"
+            - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
       - run:
           command: |
             cd ./azure
@@ -94,7 +103,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "06:b9:7d:db:59:54:db:6d:76:7b:f5:28:20:fe:d2:7d"
+            - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
       - run:
           command: |
             cd ./azure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
+            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -30,6 +31,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
+            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -49,6 +51,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
+            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -84,6 +87,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
+            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure
@@ -104,6 +108,7 @@ jobs:
       - add_ssh_keys:
           fingerprints:
             - "55:5b:db:88:e2:e4:00:87:bc:55:c2:11:52:67:d9:0d"
+            - "fa:b8:cf:a7:cd:0f:3d:19:3f:85:52:48:e6:e7:a3:39"
       - run:
           command: |
             cd ./azure

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,13 @@ workflows:
     jobs:
       - finalize-valgrind-test
 
+  # the below workflows can be used during maintenance operations on the tests in this repo
+  # simply uncomment the workflow you made changes to and push to a branch.
+  # Don't leave these workflows uncommented when merging to main
+  
   # onpush-valgrind:
   #   jobs:
   #     - valgrind-test
-  onpush-finalize-valgrind:
-    jobs:
-      - finalize-valgrind-test
+  # onpush-finalize-valgrind:
+  #   jobs:
+  #     - finalize-valgrind-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,9 +174,9 @@ workflows:
     jobs:
       - finalize-valgrind-test
 
-  onpush-valgrind:
-    jobs:
-      - valgrind-test
-  # onpush-finalize-valgrind:
+  # onpush-valgrind:
   #   jobs:
-  #     - finalize-valgrind-test
+  #     - valgrind-test
+  onpush-finalize-valgrind:
+    jobs:
+      - finalize-valgrind-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,9 @@ jobs:
       - azure-cli/install
       - azure-cli/login-with-service-principal
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "06:b9:7d:db:59:54:db:6d:76:7b:f5:28:20:fe:d2:7d"
       - run:
           command: |
             cd ./azure
@@ -89,6 +92,9 @@ jobs:
       - azure-cli/install
       - azure-cli/login-with-service-principal
       - checkout
+      - add_ssh_keys:
+          fingerprints:
+            - "06:b9:7d:db:59:54:db:6d:76:7b:f5:28:20:fe:d2:7d"
       - run:
           command: |
             cd ./azure

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -6,4 +6,8 @@ set -u
 set -e
 
 eval `ssh-agent -s`
+
+# Circle CI's specification has a list of certificates to
+# add to the job. The keys are added like id_rsa_FINGERPRINT
+# this line loads them all to the ssh-agent for later use
 ssh-add ~/.ssh/id_rsa_*

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -6,6 +6,6 @@ set -u
 set -e
 
 eval `ssh-agent -s`
-ssh-add
+ssh-add ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d
 
-ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+ssh-keygen -y -f ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d > ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d.pub

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -8,4 +8,4 @@ set -e
 eval `ssh-agent -s`
 ssh-add ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d
 
-ssh-keygen -y -f ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d > ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d.pub
+ssh-keygen -y -f ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d > ~/.ssh/id_rsa.pub

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -7,5 +7,3 @@ set -e
 
 eval `ssh-agent -s`
 ssh-add ~/.ssh/id_rsa_*
-
-ssh-keygen -y -f ~/.ssh/id_rsa_555bdb88e2e40087bc55c2115267d90d > ~/.ssh/id_rsa.pub

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -6,6 +6,6 @@ set -u
 set -e
 
 eval `ssh-agent -s`
-ssh-add ~/.ssh/id_rsa_555bdb88e2e40087bc55c2115267d90d
+ssh-add ~/.ssh/id_rsa_*
 
 ssh-keygen -y -f ~/.ssh/id_rsa_555bdb88e2e40087bc55c2115267d90d > ~/.ssh/id_rsa.pub

--- a/azure/add-sshkey.sh
+++ b/azure/add-sshkey.sh
@@ -6,6 +6,6 @@ set -u
 set -e
 
 eval `ssh-agent -s`
-ssh-add ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d
+ssh-add ~/.ssh/id_rsa_555bdb88e2e40087bc55c2115267d90d
 
-ssh-keygen -y -f ~/.ssh/id_rsa_06b97ddb5954db6d767bf52820fed27d > ~/.ssh/id_rsa.pub
+ssh-keygen -y -f ~/.ssh/id_rsa_555bdb88e2e40087bc55c2115267d90d > ~/.ssh/id_rsa.pub

--- a/azure/create-cluster.sh
+++ b/azure/create-cluster.sh
@@ -23,6 +23,11 @@ region=${AZURE_REGION:=$random_region}
 echo ${region}
 az group create -l ${region} -n ${rg}
 
+# given we might have more then one ssh key loaded we simply take the
+# first one according to ssh-add as the public key to use for the vm
+# we create in azure.
+# jobs that run in multiple stages should have the same set of keys
+# added to their invocations.
 public_key=$(ssh-add -L | head -n1 )
 
 start_time=`date +%s`
@@ -52,7 +57,6 @@ if [[ "$is_valgrind_test" != "0" ]]; then
     CREATE_CLUSTER_COMMAND+=(numberOfWorkers=0)
 fi
 
-echo "DEBUG:" ${CREATE_CLUSTER_COMMAND[@]}
 # run CREATE_CLUSTER_COMMAND
 "${CREATE_CLUSTER_COMMAND[@]}"
 

--- a/azure/create-cluster.sh
+++ b/azure/create-cluster.sh
@@ -23,7 +23,7 @@ region=${AZURE_REGION:=$random_region}
 echo ${region}
 az group create -l ${region} -n ${rg}
 
-public_key=$(cat ~/.ssh/id_rsa.pub)
+public_key=$(ssh-add -L | head -n1 )
 
 start_time=`date +%s`
 echo "waiting a long time to create cluster, this might take up to 30 mins depending on your cluster size"
@@ -52,6 +52,7 @@ if [[ "$is_valgrind_test" != "0" ]]; then
     CREATE_CLUSTER_COMMAND+=(numberOfWorkers=0)
 fi
 
+echo "DEBUG:" ${CREATE_CLUSTER_COMMAND[@]}
 # run CREATE_CLUSTER_COMMAND
 "${CREATE_CLUSTER_COMMAND[@]}"
 

--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -8,7 +8,7 @@ set -e
 set -x
 
 function cleanup {
-    sh ./delete-resource-group.sh
+    echo sh ./delete-resource-group.sh
 }
 
 export RESOURCE_GROUP_NAME="citusbot_valgrind_test_resource_group"

--- a/azure/finalize-valgrind-test.sh
+++ b/azure/finalize-valgrind-test.sh
@@ -8,7 +8,7 @@ set -e
 set -x
 
 function cleanup {
-    echo sh ./delete-resource-group.sh
+    sh ./delete-resource-group.sh
 }
 
 export RESOURCE_GROUP_NAME="citusbot_valgrind_test_resource_group"


### PR DESCRIPTION
Last month we offboarded a collaborator to the Citus Project.
Their account was linked to a hand full of ssh keys used in CI.
Among others it broke the valgrind tests.

This PR replaces ssh keys linked to an individual contributor with keys linked to the @citus-bot  account.