### PR TITLE
Remove multi_shard_commit_protocol config

### DIFF
--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -1,6 +1,10 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('14.2', 'enterprise-master'), ('14.2', 'release-10.2')]
 shard_counts_replication_factors: [(32, 1)]
+
+; Citus flags can be added below as well. E.g. citus.shard_replication_factor = 2
+; Beware of citus flags which are available in one version but not the other
+; In that case, consider creating two different configs for each version
 postgresql_conf: [
                  "max_wal_size = '50GB'",
                  "checkpoint_completion_target = 0.9",

--- a/fabfile/pgbench_confs/pgbench_default.ini
+++ b/fabfile/pgbench_confs/pgbench_default.ini
@@ -7,7 +7,6 @@ postgresql_conf: [
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
                  "max_prepared_transactions = 1000",
-                 "citus.multi_shard_commit_protocol = '2pc'"
                  ]
 use_enterprise: on
 

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,13 +1,16 @@
 [DEFAULT]
-postgres_citus_versions: [('12.1', 'enterprise-master'), ('12.1', 'release-9.2')]
+postgres_citus_versions: [('14.2', 'enterprise-master'), ('14.2', 'release-10.2')]
 shard_counts_replication_factors: [(32, 1)]
+
+; Citus flags can be added below as well. E.g. citus.shard_replication_factor = 2
+; Beware of citus flags which are available in one version but not the other
+; In that case, consider creating two different configs for each version
 postgresql_conf: [
                  "max_wal_size = '50GB'",
                  "checkpoint_completion_target = 0.9",
                  "checkpoint_timeout = '1h'",
                  "max_connections = 1000",
-                 "max_prepared_transactions = 1000",
-                 "citus.multi_shard_commit_protocol = '2pc'"
+                 "max_prepared_transactions = 1000"
                  ]
 use_enterprise: on
 


### PR DESCRIPTION
This flag is no longer available with citus 11.0
Before this flag was removed, its default value was 2pc so this config is no longer necessary.
Afaict 2pc was always the default value so this removed flag should not cause trouble even if we benchmark with much older ciuts versions