### PR TITLE
Fix "You are using an RSA key with SHA-1"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,6 @@ jobs:
       - run:
           command: |
             cd ./azure
-            ./add-sshkey.sh
             ./citus-bot.sh citusbot_pgbench_test_resource_group
           name: install dependencies and run pgbench tests
           no_output_timeout: 10m  
@@ -33,7 +32,6 @@ jobs:
       - run:
           command: |
             cd ./azure
-            ./add-sshkey.sh
             ./citus-bot.sh citusbot_scale_test_resource_group
           name: install dependencies and run scale tests
           no_output_timeout: 10m
@@ -52,7 +50,6 @@ jobs:
       - run:
           command: |
             cd ./azure
-            ./add-sshkey.sh
             ./citus-bot.sh citusbot_tpch_test_resource_group
           name: install dependencies and run tpch tests
           no_output_timeout: 10m   
@@ -87,14 +84,13 @@ jobs:
       - run:
           command: |
             cd ./azure
-            ./add-sshkey.sh
             ./citus-bot.sh citusbot_valgrind_test_resource_group
           name: install dependencies and run valgrind tests
           no_output_timeout: 10m 
 
   finalize-valgrind-test:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:focal
 
     working_directory: /home/circleci/project  
     steps:
@@ -107,7 +103,6 @@ jobs:
       - run:
           command: |
             cd ./azure
-            ./add-sshkey.sh
             ./finalize-valgrind-test.sh
           name: install dependencies and run valgrind tests
           no_output_timeout: 10m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
 
   valgrind-test:
     docker:
-      - image: buildpack-deps:trusty
+      - image: buildpack-deps:focal
 
     working_directory: /home/circleci/project  
     steps:

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -124,7 +124,7 @@
     "variables": {
         "imagePublisher": "OpenLogic",
         "imageOffer": "CentOS",
-        "imageSku": "7.2",
+        "imageSku": "7_9-gen2",
         "storageAcctName": "[take(concat(parameters('clusterName'), uniqueString(resourceGroup().id)),24)]",
         "networkSecurityGroupName": "networkSecurityGroup1",
         "vnetName": "citusVNet",

--- a/azure/citus-bot.sh
+++ b/azure/citus-bot.sh
@@ -7,6 +7,10 @@ set -e
 # echo commands
 set -x
 
+# source instead of just calling to override the ssh-agent created
+# by CircleCI
+source ./add-sshkey.sh
+
 # ssh_execute tries to send the given command over the given connection multiple times.
 # It uses the custom ssh port 3456.
 ssh_execute() {

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -156,7 +156,7 @@
     "variables": {
         "imagePublisher": "OpenLogic",
         "imageOffer": "CentOS",
-        "imageSku": "7.2",
+        "imageSku": "7_9-gen2",
         "driverImageSku" : "7.5",
         "storageAcctName": "[take(concat(parameters('clusterName'), uniqueString(resourceGroup().id)),24)]",
         "networkSecurityGroupName": "networkSecurityGroup1",


### PR DESCRIPTION
### Fix
The automated valgrind tests fail on checkout due to:
`ERROR: You are using an RSA key with SHA-1, which is no longer allowed.`
Azure VM-s fail with a similar error when trying to checkout the results repo.

As per the suggestion here:
https://discuss.circleci.com/t/circleci-user-key-uses-rsa-with-sha1-which-github-has-deprecated/42548

I updated the OS of:
* the valgrind tests form Ubuntu 14 to Ubuntu 20.
* the Azure VM-s from CentOS 7.2 to CentOS 7.9

There was nothing wrong with the keys themselves, it is a matter of the old libraries from the old OS-es which use SHA-1 to communicate with git.

### Note
Also changed the way ssh-keys are added since the agent used with the old method was being overwritten by CircleCI's agent. The commands being run in the CircleCI config were:

```bash
cd ./azure
./add-sshkeys
./citus-bot.sh ...
```

The add ssh key line creates an ssh-agent and picks up the key added via fingerprint. Ssh agent creation relies on variable exporting (e.g. AGENT_PORT, AGENT_ID etc.). Simply calling ./add-sshkeys does not export the variables declared inside the script unless explicitly calling `source ./add-sshkeys`. So the citus-bot script was just using an ssh-agent created by CircleCI and not the one we configure.

To fix that, I added `source ./add-sshkeys` inside citus-bot.sh, but I could also add `source` in front of the command in the yml.