### PR TITLE
Update HammerDb Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Hammerdb tests are run from a driver node. Driver node is in the same virtual ne
 You can customize the hammerdb cluster in the `hammerdb` folder using `hammerdb/azuredeploy.parameters.json`.
 Note that this is the configuration for the cluster, which is separate than benchmark configurations(`fabfile/hammerdb_confs/`)
 
-In `fabfile/hammerdb_confs` you can(and you should probably add at least one more config to this folder):
+In `fabfile/hammerdb_confs` you can more configs to this folder:
 
 * change postgres version
 * use enterprise or community
@@ -433,9 +433,9 @@ In `fabfile/hammerdb_confs` you can(and you should probably add at least one mor
 
 You can add as many configs as you want to `fabfile/hammerdb_confs` folder and the automation tool will
 run the benchmark for each config. So if you want to compare two branches, you can create two identical config files with two different branches. (Note that you can also use git refs instead of branch names)
-Even though the script will clean all the tables in each iteration to get more accurate results, the disk
-cache is likely to inflate the results of the tests running after the first file so for the most unbiased results test the setups 
-seperately (repeat this produre twice). 
+Even though the script will vacuum the tables in each iteration to get more accurate results, the disk
+cache is likely to inflate the results of the tests running after the first file so for the most unbiased results 
+test the setups seperately (repeat this produre twice). 
 The result logs will contain the config file so that it is easy to know which config was used for a run.
 
 After adding the configs `fabfile/hammerdb_confs` could look like:
@@ -464,11 +464,19 @@ vim fabfile/hammerdb_confs/<branch_name>.ini # verify that your custom config fi
 
 **After running ./create-run.sh you do not have to be connected to the driver node at all, it will take care of the rest for you.**
 
-**The cluster will be deleted if everything goes okay, but you should check if it is deleted to be on the safe side.(If it is not, you can delete that with azure/delete-resource-group.sh or from the portal).**
+The cluster deployment is flaky and sometimes it will fail. This behaviour is somewhat rare so it is not a
+big problem. In that case, simply delete the previous resource group, and try again.
+You can do that with:
+```bash
+# running from the same shell where you called create-run.sh to start the test
+../azure/delete-resource-group.sh
+./create-run.sh
+``` 
 
-Sometimes you might get random/temporary errors while provisining the cluster. In that case, simply
-delete the previous resource group, and try again. If it is persistent, try after a while, and if it is still
-persistent open an issue on test-automation.
+If it is persistent, some policy might have been changed on Azure so either consider debugging the issue,
+or opening an issue in test-automation.
+
+**The cluster will be deleted if everything goes okay, but you should check if it is deleted to be on the safe side.(If it is not, you can delete that with azure/delete-resource-group.sh or from the portal).**
 
 In order to see the process of the tests, from the driver node:
 

--- a/README.md
+++ b/README.md
@@ -417,8 +417,8 @@ pgbench_command: pgbench -c 32 -j 16 -T <test time in seconds> -P 10 -r
 
 ## <a name="running-automated-hammerdb-benchmark"></a>Running Automated Hammerdb Benchmark
 
-**You should create a new branch and change the settings in the new branch and push the branch so that
-when the tool clones the repository it can download your branch.**
+**Important:** Push your branch to the github repo even though the HammerDb tests are run from your local.
+The initiliazer script used to setup the Azure VM-s will pull your branch from github and not from your local.
 
 Hammerdb tests are run from a driver node. Driver node is in the same virtual network as the cluster.
 You can customize the hammerdb cluster in the `hammerdb` folder using `hammerdb/azuredeploy.parameters.json`.

--- a/README.md
+++ b/README.md
@@ -424,7 +424,7 @@ Hammerdb tests are run from a driver node. Driver node is in the same virtual ne
 You can customize the hammerdb cluster in the `hammerdb` folder using `hammerdb/azuredeploy.parameters.json`.
 Note that this is the configuration for the cluster, which is separate than benchmark configurations(`fabfile/hammerdb_confs/`)
 
-In `fabfile/hammerdb_confs` you can more configs to this folder:
+In `fabfile/hammerdb_confs` you can add more configs to this folder:
 
 * change postgres version
 * use enterprise or community

--- a/fabfile/hammerdb_confs/citus_config.ini
+++ b/fabfile/hammerdb_confs/citus_config.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_version: ('14.3', 'release-11.0')
+postgres_citus_version: ('14.3', 'release-10.2')
 postgresql_conf: [
     # the following two are necessary to prevent getting timeouts, do not change them.
     "tcp_keepalives_idle = 120",

--- a/fabfile/hammerdb_confs/citus_config.ini
+++ b/fabfile/hammerdb_confs/citus_config.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_version: ('14.2', 'enterprise-master')
+postgres_citus_version: ('14.3', 'release-11.0')
 postgresql_conf: [
     # the following two are necessary to prevent getting timeouts, do not change them.
     "tcp_keepalives_idle = 120",

--- a/fabfile/hammerdb_confs/citus_config.ini
+++ b/fabfile/hammerdb_confs/citus_config.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_version: ('14.3', 'release-10.2')
+postgres_citus_version: ('14.3', 'release-11.0')
 postgresql_conf: [
     # the following two are necessary to prevent getting timeouts, do not change them.
     "tcp_keepalives_idle = 120",

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -157,7 +157,7 @@
         "imagePublisher": "OpenLogic",
         "imageOffer": "CentOS",
         "imageSku": "7_9-gen2",
-        "driverImageSku" : "7.5",
+        "driverImageSku" : "7_9-gen2",
         "storageAcctName": "[take(concat(parameters('clusterName'), uniqueString(resourceGroup().id)),24)]",
         "networkSecurityGroupName": "networkSecurityGroup1",
         "vnetName": "citusVNet",

--- a/hammerdb/azuredeploy.json
+++ b/hammerdb/azuredeploy.json
@@ -239,7 +239,7 @@
                             "sourceAddressPrefix": "*",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
-                            "priority": 102,
+                            "priority": 101,
                             "direction": "Inbound"
                         }
                     },
@@ -253,7 +253,7 @@
                             "sourceAddressPrefix": "[parameters('localPublicIp')]",
                             "destinationAddressPrefix": "*",
                             "access": "Allow",
-                            "priority": 110,
+                            "priority": 102,
                             "direction": "Inbound"
                         }
                     }

--- a/hammerdb/create-run.sh
+++ b/hammerdb/create-run.sh
@@ -8,7 +8,7 @@ set -e
 set -x
 
 is_tpcc=${IS_TPCC:=true} # set to true if you want tpcc to be run, otherwise set to false
-is_ch=${IS_CH:=true} # set to true if you want ch benchmark to be run, otherwise set to false
+is_ch=${IS_CH:=false} # set to true if you want ch benchmark to be run, otherwise set to false
 username=pguser # username of the database
 hammerdb_version=4.4 # (4.4+ recommended) find available versions in download-hammerdb.sh
 


### PR DESCRIPTION
* Update README.md
* Update the driver VM version to recent CentOS
* Switch ch_benchmark off by default since we most commonly use `hammerdb/create-run.sh` to run the hammerdb benchmarks and use tpch for analytical workloads.