### PR TITLE
Report query string on memory error

### DIFF
--- a/azure/init.sh
+++ b/azure/init.sh
@@ -88,7 +88,7 @@ semanage port -a -t ssh_port_t -p tcp 3456
 # restart ssh service to be able to use the new port
 systemctl restart sshd
 
-BRANCH="report_query_on_error"
+BRANCH=$5
 
 echo ${BRANCH} > /tmp/branch_name
 

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -88,7 +88,7 @@ semanage port -a -t ssh_port_t -p tcp 3456
 # restart ssh service to be able to use the new port
 systemctl restart sshd
 
-BRANCH=$5
+BRANCH="report_query_on_error"
 
 echo ${BRANCH} > /tmp/branch_name
 

--- a/fabfile/pg_report_vg_query.patch
+++ b/fabfile/pg_report_vg_query.patch
@@ -1,0 +1,39 @@
+diff --git a/src/backend/tcop/postgres.c b/src/backend/tcop/postgres.c
+index 470b734e9e..0798dff410 100644
+--- a/src/backend/tcop/postgres.c
++++ b/src/backend/tcop/postgres.c
+@@ -73,6 +73,9 @@
+ #include "utils/snapmgr.h"
+ #include "utils/timeout.h"
+ #include "utils/timestamp.h"
++#ifdef USE_VALGRIND
++#include <valgrind/valgrind.h>
++#endif
+ 
+ /* ----------------
+  *		global variables
+@@ -986,6 +989,7 @@ exec_simple_query(const char *query_string)
+ 	bool		was_logged = false;
+ 	bool		use_implicit_block;
+ 	char		msec_str[32];
++	static long long unsigned vgErrorsSoFar = 0;
+ 
+ 	/*
+ 	 * Report query to various monitoring facilities.
+@@ -1343,6 +1347,16 @@ exec_simple_query(const char *query_string)
+ 	TRACE_POSTGRESQL_QUERY_DONE(query_string);
+ 
+ 	debug_query_string = NULL;
++
++#ifdef USE_VALGRIND
++	if (VALGRIND_COUNT_ERRORS > vgErrorsSoFar)
++	{
++		VALGRIND_PRINTF("The query for which valgrind reported a "
++						"memory error was: %s\n",
++						query_string);
++	}
++	vgErrorsSoFar = VALGRIND_COUNT_ERRORS;
++#endif
+ }
+ 
+ /*

--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -251,6 +251,10 @@ def build_postgres(c):
         c.run('tar -xf {}.tar.bz2'.format(final_dir), hide='stdout')
 
         with c.cd(final_dir):
+            # apply the patch that helps reporting the queries that cause memory errors under valgrind
+            patch_path = os.path.join(config.HOME_DIR, "test-automation/fabfile/pg_report_vg_query.patch")
+            c.run('git apply {}'.format(patch_path))
+
             pg_latest = config.PG_LATEST
             flags = ' '.join(config.PG_CONFIGURE_FLAGS)
             c.run('./configure --prefix={} {}'.format(pg_latest, flags), hide='stdout')


### PR DESCRIPTION
Patch the changes proposed in https://github.com/onurctirtir/postgres/tree/report-query-str-on-mem-error to Postgres before making it.

That way, we will save the queries that result in memory errors in valgrind test output, right after relevant stack traces.

This allows us to collect such outputs:
```c
==124387== VALGRINDERROR-BEGIN
==124387== Invalid write of size 8
==124387==    at 0x7A6EFA8: dlist_delete (home/pguser/postgres-installation/include/postgresql/server/lib/ilist.h:361)
==124387==    by 0x7A6EFA8: ResetRemoteTransaction (home/pguser/citus/src/backend/distributed/transaction/remote_transaction.c:872)
==124387==    by 0x79CF5EC: AfterXactHostConnectionHandling (home/pguser/citus/src/backend/distributed/connection/connection_management.c:1467)
==124387==    by 0x79CF644: AfterXactConnectionHandling (home/pguser/citus/src/backend/distributed/connection/connection_management.c:175)
==124387==    by 0x7A6FE37: CoordinatedTransactionCallback (home/pguser/citus/src/backend/distributed/transaction/transaction_management.c:309)
==124387==    by 0x544F30: CallXactCallbacks (home/pguser/postgres-source/postgresql-15.1/src/backend/access/transam/xact.c:3661)
==124387==    by 0x548E12: CommitTransaction (home/pguser/postgres-source/postgresql-15.1/src/backend/access/transam/xact.c:2298)
==124387==    by 0x549BBC: CommitTransactionCommand (home/pguser/postgres-source/postgresql-15.1/src/backend/access/transam/xact.c:3048)
==124387==    by 0x832C30: finish_xact_command (home/pguser/postgres-source/postgresql-15.1/src/backend/tcop/postgres.c:2750)
==124387==    by 0x8352AF: exec_simple_query (home/pguser/postgres-source/postgresql-15.1/src/backend/tcop/postgres.c:1279)
==124387==    by 0x837312: PostgresMain (home/pguser/postgres-source/postgresql-15.1/src/backend/tcop/postgres.c:4595)
==124387==    by 0x79F7B5: BackendRun (home/pguser/postgres-source/postgresql-15.1/src/backend/postmaster/postmaster.c:4504)
==124387==    by 0x7A24E6: BackendStartup (home/pguser/postgres-source/postgresql-15.1/src/backend/postmaster/postmaster.c:4232)
==124387==  Address 0x7486ed0 is 6,160 bytes inside a recently re-allocated block of size 8,192 alloc'd
==124387==    at 0x484486F: malloc (builddir/build/BUILD/valgrind-3.19.0/coregrind/m_replacemalloc/vg_replace_malloc.c:381)
==124387==    by 0x98B6EB: AllocSetContextCreateInternal (home/pguser/postgres-source/postgresql-15.1/src/backend/utils/mmgr/aset.c:469)
==124387==    by 0x79CEAA0: InitializeConnectionManagement (home/pguser/citus/src/backend/distributed/connection/connection_management.c:107)
==124387==    by 0x799FE9F: _PG_init (home/pguser/citus/src/backend/distributed/shared_library_init.c:464)
==124387==    by 0x96AE6B: internal_load_library (home/pguser/postgres-source/postgresql-15.1/src/backend/utils/fmgr/dfmgr.c:289)
==124387==    by 0x96B09A: load_file (home/pguser/postgres-source/postgresql-15.1/src/backend/utils/fmgr/dfmgr.c:156)
==124387==    by 0x973122: load_libraries (home/pguser/postgres-source/postgresql-15.1/src/backend/utils/init/miscinit.c:1668)
==124387==    by 0x974680: process_shared_preload_libraries (home/pguser/postgres-source/postgresql-15.1/src/backend/utils/init/miscinit.c:1686)
==124387==    by 0x7A336A: PostmasterMain (home/pguser/postgres-source/postgresql-15.1/src/backend/postmaster/postmaster.c:1026)
==124387==    by 0x6F303C: main (home/pguser/postgres-source/postgresql-15.1/src/backend/main/main.c:202)
==124387== 
==124387== VALGRINDERROR-END
**124387** The query for which valgrind reported a memory error was: INSERT INTO replicated SELECT i,i FROM generate_series(0,10)i;
```
