### PR TITLE
Update scripts

### DIFF
--- a/azure/azuredeploy.parameters.json
+++ b/azure/azuredeploy.parameters.json
@@ -3,7 +3,7 @@
     "contentVersion": "1.0.0.0",
     "parameters": {
         "numberOfWorkers": {
-            "value": 1
+            "value": 2
         },
         "diskType": {
             "value": "Premium_LRS"

--- a/fabfile/requirements.txt
+++ b/fabfile/requirements.txt
@@ -1,4 +1,4 @@
 Fabric==2.7.1
-paramiko==2.11.0
+paramiko==3.4.1
 patchwork==1.0.1
 invoke==1.7.3

--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -216,7 +216,7 @@ def redhat_install_packages(c):
     # you can detect amazon linux with /etc/issue and redhat with /etc/redhat-release
     c.sudo("yum groupinstall -q -y 'Development Tools'", hide='stdout')
 
-    c.sudo('yum install -q -y libxml2-devel libxslt-devel'
+    c.sudo('yum install -q -y libxml2-devel libxslt-devel libicu-devel'
         ' openssl-devel pam-devel readline-devel libcurl-devel'
         ' git libzstd-devel lz4-devel perl-IPC-Run perl-Test-Simple'
         ' perl-Test-Harness perl-Time-HiRes perl-FindBin', hide='stdout')

--- a/fabfile/setup.py
+++ b/fabfile/setup.py
@@ -219,7 +219,7 @@ def redhat_install_packages(c):
     c.sudo('yum install -q -y libxml2-devel libxslt-devel'
         ' openssl-devel pam-devel readline-devel libcurl-devel'
         ' git libzstd-devel lz4-devel perl-IPC-Run perl-Test-Simple'
-        ' perl-Test-Harness perl-Time-HiRes', hide='stdout')
+        ' perl-Test-Harness perl-Time-HiRes perl-FindBin', hide='stdout')
 
 # cache to not build and install the same version of postgres or extensions
 # we will only reinstall pg if its version changes.


### PR DESCRIPTION
- Fix error: Can't locate FindBin.pm
- Bump paramiko version to 3.4.1
Was getting Deprecation Warning for TripleDES Algorithm in Paramiko
Something like:
"CryptographyDeprecationWarning: TripleDES has been moved to
 cryptography.hazmat.decrepit.ciphers.algorithms.TripleDES
 and will be removed from this module"
Therefore I bumped the version.
- Use at least 2 workers for Citus capabilities
- Since PG16, the ICU library is used by default