### PR TITLE
Fix init.sh to retry connecting to redhat repositories

### DIFF
--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -411,14 +411,6 @@
                     ]
                 }
             },
-            "dependsOn": [
-                "virtualMachineLoop",
-                "nicLoop",
-                "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), copyIndex()))]",
-                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
-                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts/', variables('storageAcctName'))]"
-            ],
             "copy": {
                 "name": "extensionScriptLoop",
                 "count": "[variables('numberOfInstances')]"

--- a/azure/azuredeploy.json
+++ b/azure/azuredeploy.json
@@ -411,6 +411,14 @@
                     ]
                 }
             },
+            "dependsOn": [
+                "virtualMachineLoop",
+                "nicLoop",
+                "[resourceId('Microsoft.Network/publicIPAddresses', concat(variables('publicIPAddressName'), copyIndex()))]",
+                "[resourceId('Microsoft.Network/networkSecurityGroups', variables('networkSecurityGroupName'))]",
+                "[resourceId('Microsoft.Network/virtualNetworks', variables('vnetName'))]",
+                "[resourceId('Microsoft.Storage/storageAccounts/', variables('storageAcctName'))]"
+            ],
             "copy": {
                 "name": "extensionScriptLoop",
                 "count": "[variables('numberOfInstances')]"

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -21,9 +21,32 @@ echo "arg6 = $6"
 firewall-cmd --add-port=5432/tcp || true
 firewall-cmd --add-port=3456/tcp || true
 
-
 # fail in a pipeline if any of the commands fails
 set -o pipefail
+
+
+# retry until yum repos become available
+max_retries=50
+count=1
+
+while (( count <= max_retries )); do
+    echo "Attempt $count of $max_retries: Installing hostname..."
+    
+    # Try installing the package
+    if yum install -y hostname; then
+        echo "Successfully installed hostname."
+        break
+    else
+        echo "Install failed (exit code $?). Retrying in 10 seconds..."
+        sleep 10
+    fi
+    ((count++))
+done
+
+if (( count > max_retries )); then
+    echo "Failed to install hostname after $max_retries attempts." 
+    exit 1
+fi
 
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -7,6 +7,14 @@ set -e
 # echo commands
 set -x
 
+# print args
+echo "arg1 = $1"
+echo "arg2 = $2"
+echo "arg3 = $3"
+echo "arg4 = $4"
+echo "arg5 = $5"
+echo "arg6 = $6"
+
 # in redhat we need to enable default port for postgres
 # We don't exit on this command because if we are on centos, the firewall
 # might not be active, but this also enables switching to redhat easily.
@@ -16,12 +24,6 @@ firewall-cmd --add-port=3456/tcp || true
 
 # fail in a pipeline if any of the commands fails
 set -o pipefail
-
-rm -r /var/cache/dnf
-
-# install & update ca certificates
-yum install -y ca-certificates
-update-ca-trust -f
 
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -34,6 +36,10 @@ yum install -y screen htop
 
 # install tmux
 yum install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
+
+# install & update ca certificates
+yum install -y ca-certificates
+update-ca-trust -f
 
 # install python3 package manager pip
 yum install -y python3-pip

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,24 +17,26 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
+sudo rm -r /var/cache/dnf
+
 # install epel repo
-yum -y --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 # install git to clone the repository
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y git
+yum install -y git
 
 # install other utility tools
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y screen htop
+yum install -y screen htop
 
 # install tmux
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
+yum install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
 
 # install & update ca certificates
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y ca-certificates
+yum install -y ca-certificates
 update-ca-trust -f
 
 # install python3 package manager pip
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y python3-pip
+yum install -y python3-pip
 
 # this is the username in our instances
 TARGET_USER=pguser
@@ -68,7 +70,7 @@ mkfs -t ext4 ${DEV}
 mv /home/${TARGET_USER}/ /tmp/home_copy
 mkdir -p /home/${TARGET_USER}
 mount -o barrier=0 ${DEV} /home/${TARGET_USER}/
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y rsync
+yum install -y rsync
 rsync -aXS /tmp/home_copy/. /home/${TARGET_USER}/.
 
 
@@ -81,7 +83,7 @@ echo 'Port 3456' >> /etc/ssh/sshd_config
 echo 'Port 22' >> /etc/ssh/sshd_config
 
 # necessary for semanage, VMs have secure linux
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y policycoreutils-python-utils
+yum install -y policycoreutils-python-utils
 # we need to enable the new port from semanage
 semanage port -a -t ssh_port_t -p tcp 3456
 
@@ -129,8 +131,8 @@ EOSU
 
 find_private_ips() {
   rpm --import https://packages.microsoft.com/keys/microsoft.asc
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y azure-cli
+  yum install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+  yum install -y azure-cli
 
   mkdir /home/log
   chmod og+rwx /home/log
@@ -144,7 +146,7 @@ find_private_ips() {
     echo $i >>$LOGS
   done
 
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y hostname
+  yum install -y hostname
   hostname -I >/home/log/ip_address
 
   export NODE_ID=$1

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -24,30 +24,6 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
-
-# retry until yum repos become available
-max_retries=50
-count=1
-
-while (( count <= max_retries )); do
-    echo "Attempt $count of $max_retries: Installing hostname..."
-    
-    # Try installing the package
-    if yum install -y hostname; then
-        echo "Successfully installed hostname."
-        break
-    else
-        echo "Install failed (exit code $?). Retrying in 10 seconds..."
-        sleep 10
-    fi
-    ((count++))
-done
-
-if (( count > max_retries )); then
-    echo "Failed to install hostname after $max_retries attempts." 
-    exit 1
-fi
-
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,7 +17,11 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
-sudo rm -r /var/cache/dnf
+rm -r /var/cache/dnf
+
+# install & update ca certificates
+yum install -y ca-certificates
+update-ca-trust -f
 
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
@@ -30,10 +34,6 @@ yum install -y screen htop
 
 # install tmux
 yum install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
-
-# install & update ca certificates
-yum install -y ca-certificates
-update-ca-trust -f
 
 # install python3 package manager pip
 yum install -y python3-pip

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,7 +17,7 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
-yum makecache
+yum update ca-certificates -y
 
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,26 +17,24 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
-yum update ca-certificates -y
-
 # install epel repo
-yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+yum -y --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 # install git to clone the repository
-yum install -y git
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y git
 
 # install other utility tools
-yum install -y screen htop
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y screen htop
 
 # install tmux
-yum install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
 
 # install & update ca certificates
-yum install -y ca-certificates
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y ca-certificates
 update-ca-trust -f
 
 # install python3 package manager pip
-yum install -y python3-pip
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y python3-pip
 
 # this is the username in our instances
 TARGET_USER=pguser
@@ -70,7 +68,7 @@ mkfs -t ext4 ${DEV}
 mv /home/${TARGET_USER}/ /tmp/home_copy
 mkdir -p /home/${TARGET_USER}
 mount -o barrier=0 ${DEV} /home/${TARGET_USER}/
-yum install -y rsync
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y rsync
 rsync -aXS /tmp/home_copy/. /home/${TARGET_USER}/.
 
 
@@ -83,7 +81,7 @@ echo 'Port 3456' >> /etc/ssh/sshd_config
 echo 'Port 22' >> /etc/ssh/sshd_config
 
 # necessary for semanage, VMs have secure linux
-yum install -y policycoreutils-python-utils
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y policycoreutils-python-utils
 # we need to enable the new port from semanage
 semanage port -a -t ssh_port_t -p tcp 3456
 
@@ -131,8 +129,8 @@ EOSU
 
 find_private_ips() {
   rpm --import https://packages.microsoft.com/keys/microsoft.asc
-  yum install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
-  yum install -y azure-cli
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y azure-cli
 
   mkdir /home/log
   chmod og+rwx /home/log
@@ -146,7 +144,7 @@ find_private_ips() {
     echo $i >>$LOGS
   done
 
-  yum install -y hostname
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y hostname
   hostname -I >/home/log/ip_address
 
   export NODE_ID=$1

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -18,23 +18,23 @@ firewall-cmd --add-port=3456/tcp || true
 set -o pipefail
 
 # install epel repo
-yum -y --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+yum -y --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 
 # install git to clone the repository
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y git
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y git
 
 # install other utility tools
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y screen htop
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y screen htop
 
 # install tmux
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y http://mirror.stream.centos.org/9-stream/BaseOS/x86_64/os/Packages/tmux-3.2a-4.el9.x86_64.rpm
 
 # install & update ca certificates
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y ca-certificates
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y ca-certificates
 update-ca-trust -f
 
 # install python3 package manager pip
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y python3-pip
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y python3-pip
 
 # this is the username in our instances
 TARGET_USER=pguser
@@ -68,7 +68,7 @@ mkfs -t ext4 ${DEV}
 mv /home/${TARGET_USER}/ /tmp/home_copy
 mkdir -p /home/${TARGET_USER}
 mount -o barrier=0 ${DEV} /home/${TARGET_USER}/
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y rsync
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y rsync
 rsync -aXS /tmp/home_copy/. /home/${TARGET_USER}/.
 
 
@@ -81,7 +81,7 @@ echo 'Port 3456' >> /etc/ssh/sshd_config
 echo 'Port 22' >> /etc/ssh/sshd_config
 
 # necessary for semanage, VMs have secure linux
-yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y policycoreutils-python-utils
+yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y policycoreutils-python-utils
 # we need to enable the new port from semanage
 semanage port -a -t ssh_port_t -p tcp 3456
 
@@ -129,8 +129,8 @@ EOSU
 
 find_private_ips() {
   rpm --import https://packages.microsoft.com/keys/microsoft.asc
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y azure-cli
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y https://packages.microsoft.com/config/rhel/9.0/packages-microsoft-prod.rpm
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y azure-cli
 
   mkdir /home/log
   chmod og+rwx /home/log
@@ -144,7 +144,7 @@ find_private_ips() {
     echo $i >>$LOGS
   done
 
-  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms install -y hostname
+  yum --disablerepo rhel-9-for-x86_64-supplementary-rhui-rpms,codeready-builder-for-rhel-9-x86_64-rhui-rpms install -y hostname
   hostname -I >/home/log/ip_address
 
   export NODE_ID=$1

--- a/azure/init.sh
+++ b/azure/init.sh
@@ -17,6 +17,8 @@ firewall-cmd --add-port=3456/tcp || true
 # fail in a pipeline if any of the commands fails
 set -o pipefail
 
+yum makecache
+
 # install epel repo
 yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 

--- a/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
+++ b/fabfile/pgbench_confs/pgbench_default_without_transaction.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-postgres_citus_versions: [('15.1', 'main')]
+postgres_citus_versions: [('17.5', 'release-13.2')]
 shard_counts_replication_factors: [(32, 1)]
 
 ; Citus flags can be added below as well. E.g. citus.shard_replication_factor = 2

--- a/fabfile/tpch_confs/tpch_default.ini
+++ b/fabfile/tpch_confs/tpch_default.ini
@@ -1,5 +1,5 @@
 [test]
-postgres_citus_versions: [('14.3', 'release-11.0')]
+postgres_citus_versions: [('17.5', 'release-13.2')]
 tpch_tasks_executor_types: [('1.sql', 'adaptive'), ('3.sql', 'adaptive'), ('5.sql', 'adaptive'), ('6.sql', 'adaptive')
                             ,('7.sql', 'adaptive'), ('8.sql', 'adaptive'), ('9.sql', 'adaptive'), ('10.sql', 'adaptive')
                             , ('12.sql', 'adaptive'), ('14.sql', 'adaptive'), ('19.sql', 'adaptive')]

--- a/fabfile/tpch_confs/tpch_q1.ini
+++ b/fabfile/tpch_confs/tpch_q1.ini
@@ -1,4 +1,4 @@
 [test]
-postgres_citus_versions: [('12.1', 'release-11.0')]
+postgres_citus_versions: [('17.5', 'release-13.2')]
 tpch_tasks_executor_types: [('1.sql', 'real-time')]
 scale_factor: 1


### PR DESCRIPTION
This PR fixes the problem about `create-cluser.sh` failing to automatically provision clusters for testing. 

Because azure is deploying resources in parallel, and at the time custom-script extension runs init.sh, redhat repositories could not be resolved. This is most probably because network resources are not fully deployed during that time. 
 
To test the theory, I placed a while loop in the init.sh which just tries to install hostname package until it succeeds, or sleeps 10 seconds if it fails, and retries that some 50 times. 

With this patch, `create-cluster.sh` can now succeed. 